### PR TITLE
feat: Auth proxy support (Authelia, Authentik, Keycloak, oauth2-proxy)

### DIFF
--- a/Open UI/Core/Models/ServerConfig.swift
+++ b/Open UI/Core/Models/ServerConfig.swift
@@ -34,6 +34,21 @@ struct ServerConfig: Codable, Identifiable, Hashable, Sendable {
     /// Used to skip health check on reconnect and to gate CF-specific behaviour.
     var isCloudflareBotProtected: Bool
 
+    // MARK: - Auth Proxy persistence (Authelia, Authentik, Keycloak, etc.)
+
+    /// Cookies captured from WKWebView after the user authenticated through
+    /// an upstream auth proxy (Authelia, Authentik, Keycloak, oauth2-proxy, etc.).
+    /// Persisted as JSON-encoded `[name: value]` dictionary so they can be
+    /// re-injected into `HTTPCookieStorage.shared` on app restart.
+    var proxyAuthCookies: [String: String]?
+
+    /// Whether this server is known to be behind an auth proxy.
+    /// Used to re-inject proxy cookies on reconnect and to gate proxy-specific behaviour.
+    var isAuthProxyProtected: Bool
+
+    /// The URL the proxy redirected to (auth portal URL) — used to re-scope cookies.
+    var proxyAuthPortalURL: String?
+
     /// API key — stored in Keychain, NOT serialised to UserDefaults.
     /// Populated transiently at runtime via ``KeychainService``.
     var apiKey: String?
@@ -42,6 +57,7 @@ struct ServerConfig: Codable, Identifiable, Hashable, Sendable {
     enum CodingKeys: String, CodingKey {
         case id, name, url, customHeaders, lastConnected, isActive, allowSelfSignedCertificates
         case cfClearanceValue, cfClearanceExpiry, cfUserAgent, isCloudflareBotProtected
+        case proxyAuthCookies, isAuthProxyProtected, proxyAuthPortalURL
     }
 
     init(
@@ -56,7 +72,10 @@ struct ServerConfig: Codable, Identifiable, Hashable, Sendable {
         cfClearanceValue: String? = nil,
         cfClearanceExpiry: Date? = nil,
         cfUserAgent: String? = nil,
-        isCloudflareBotProtected: Bool = false
+        isCloudflareBotProtected: Bool = false,
+        proxyAuthCookies: [String: String]? = nil,
+        isAuthProxyProtected: Bool = false,
+        proxyAuthPortalURL: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -70,6 +89,9 @@ struct ServerConfig: Codable, Identifiable, Hashable, Sendable {
         self.cfClearanceExpiry = cfClearanceExpiry
         self.cfUserAgent = cfUserAgent
         self.isCloudflareBotProtected = isCloudflareBotProtected
+        self.proxyAuthCookies = proxyAuthCookies
+        self.isAuthProxyProtected = isAuthProxyProtected
+        self.proxyAuthPortalURL = proxyAuthPortalURL
     }
 
     /// Whether the persisted `cf_clearance` cookie is still valid (not expired).

--- a/Open UI/Core/Networking/APIClient.swift
+++ b/Open UI/Core/Networking/APIClient.swift
@@ -350,6 +350,96 @@ final class APIClient: @unchecked Sendable {
         )
     }
 
+    /// Fetches full model configuration from `/api/v1/models/model?id={id}`.
+    ///
+    /// Unlike `/api/models` (which returns a lightweight list without `params`),
+    /// this endpoint returns the complete model config including:
+    /// - `params.function_calling` — "native" or absent (for default mode)
+    /// - `meta.capabilities` — all capabilities
+    /// - `meta.builtinTools` — which builtin tools are enabled
+    /// - `meta.toolIds` — server-assigned tools
+    /// - `meta.defaultFeatureIds` — default features like web_search, image_generation
+    ///
+    /// Called when a model is selected to get authoritative config for that model.
+    func fetchModelConfig(modelId: String) async throws -> AIModel? {
+        let raw = try await getModelDetails(modelId: modelId)
+        return parseModelConfig(raw)
+    }
+
+    /// Parses a full model config response from `/api/v1/models/model`.
+    /// The schema differs from the `/api/models` list — `params` and `meta` are top-level,
+    /// not nested under `info`.
+    func parseModelConfig(_ raw: [String: Any]) -> AIModel? {
+        guard let id = raw["id"] as? String else { return nil }
+        let name = raw["name"] as? String ?? id
+
+        var isMultimodal = false
+        var supportsRAG = false
+        var capabilities: [String: String]?
+        var profileImageURL: String?
+        var toolIds: [String] = []
+        var defaultFeatureIds: [String] = []
+        var functionCallingMode: String?
+
+        // Top-level `params` (present in single-model endpoint)
+        if let params = raw["params"] as? [String: Any] {
+            if let fc = params["function_calling"] as? String, !fc.isEmpty {
+                functionCallingMode = fc
+            }
+        }
+
+        // Top-level `meta` (present in single-model endpoint)
+        if let meta = raw["meta"] as? [String: Any] {
+            profileImageURL = meta["profile_image_url"] as? String
+            if let caps = meta["capabilities"] as? [String: Any] {
+                isMultimodal = caps["vision"] as? Bool ?? false
+                supportsRAG = caps["citations"] as? Bool ?? false
+                capabilities = caps.compactMapValues { "\($0)" }
+            }
+            if let tools = meta["toolIds"] as? [String] {
+                toolIds = tools
+            }
+            if let defaultFeatures = meta["defaultFeatureIds"] as? [String] {
+                defaultFeatureIds = defaultFeatures
+            }
+        }
+
+        // Fallback: `info.meta` (present in list endpoint — allows reuse for both)
+        if let info = raw["info"] as? [String: Any] {
+            if let meta = info["meta"] as? [String: Any] {
+                if profileImageURL == nil {
+                    profileImageURL = meta["profile_image_url"] as? String
+                }
+                if capabilities == nil, let caps = meta["capabilities"] as? [String: Any] {
+                    isMultimodal = caps["vision"] as? Bool ?? false
+                    supportsRAG = caps["citations"] as? Bool ?? false
+                    capabilities = caps.compactMapValues { "\($0)" }
+                }
+                if toolIds.isEmpty, let tools = meta["toolIds"] as? [String] {
+                    toolIds = tools
+                }
+                if defaultFeatureIds.isEmpty, let defaultFeatures = meta["defaultFeatureIds"] as? [String] {
+                    defaultFeatureIds = defaultFeatures
+                }
+            }
+        }
+
+        return AIModel(
+            id: id,
+            name: name,
+            description: raw["description"] as? String,
+            isMultimodal: isMultimodal,
+            supportsStreaming: true,
+            supportsRAG: supportsRAG,
+            contextLength: raw["context_length"] as? Int,
+            capabilities: capabilities,
+            profileImageURL: profileImageURL,
+            toolIds: toolIds,
+            defaultFeatureIds: defaultFeatureIds,
+            functionCallingMode: functionCallingMode
+        )
+    }
+
     // MARK: - Conversations
 
     /// Fetches conversations including pinned status.
@@ -1641,6 +1731,7 @@ final class APIClient: @unchecked Sendable {
             var profileImageURL: String?
             var toolIds: [String] = []
             var defaultFeatureIds: [String] = []
+            var functionCallingMode: String?
 
             if let info = raw["info"] as? [String: Any] {
                 if let meta = info["meta"] as? [String: Any] {
@@ -1657,6 +1748,15 @@ final class APIClient: @unchecked Sendable {
                         defaultFeatureIds = defaultFeatures
                     }
                 }
+                // Parse function_calling mode from info.params.
+                // OpenWebUI stores this as: info.params.function_calling = "native" | ""
+                // When "native", the model performs native tool calling.
+                // When absent/empty, the server uses its default (non-native) handling.
+                if let params = info["params"] as? [String: Any] {
+                    if let fc = params["function_calling"] as? String, !fc.isEmpty {
+                        functionCallingMode = fc
+                    }
+                }
             }
 
             return AIModel(
@@ -1670,7 +1770,8 @@ final class APIClient: @unchecked Sendable {
                 capabilities: capabilities,
                 profileImageURL: profileImageURL,
                 toolIds: toolIds,
-                defaultFeatureIds: defaultFeatureIds
+                defaultFeatureIds: defaultFeatureIds,
+                functionCallingMode: functionCallingMode
             )
         }
     }

--- a/Open UI/Core/Networking/NetworkManager.swift
+++ b/Open UI/Core/Networking/NetworkManager.swift
@@ -60,6 +60,29 @@ final class NetworkManager: NSObject, Sendable {
             }
         }
 
+        // Re-inject persisted auth proxy cookies on startup (Authelia, Authentik, etc.).
+        // These are session cookies with no expiry — they vanish when the app terminates,
+        // so we persist the values in ServerConfig and re-create them here on every launch.
+        if serverConfig.isAuthProxyProtected,
+           let proxyAuthCookies = serverConfig.proxyAuthCookies,
+           !proxyAuthCookies.isEmpty,
+           let url = URL(string: serverConfig.url),
+           let host = url.host {
+            for (name, value) in proxyAuthCookies {
+                let cookieProperties: [HTTPCookiePropertyKey: Any] = [
+                    .name: name,
+                    .value: value,
+                    .domain: host,
+                    .path: "/",
+                    .secure: url.scheme == "https" ? "TRUE" : "FALSE"
+                ]
+                if let cookie = HTTPCookie(properties: cookieProperties) {
+                    HTTPCookieStorage.shared.setCookie(cookie)
+                }
+            }
+            logger.info("🔐 Re-injected \(proxyAuthCookies.count) persisted proxy auth cookie(s) for \(host)")
+        }
+
         var headers = configuration.httpAdditionalHeaders ?? [:]
         for (key, value) in serverConfig.customHeaders {
             headers[key] = value
@@ -556,7 +579,7 @@ private final class CertificateTrustDelegate: NSObject, URLSessionDelegate, Send
         super.init()
     }
 
-    func urlSession(
+    nonisolated func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
@@ -569,7 +592,7 @@ private final class CertificateTrustDelegate: NSObject, URLSessionDelegate, Send
             return
         }
 
-        guard let baseURL = serverConfig.apiBaseURL,
+        guard let baseURL = URL(string: serverConfig.url),
               challenge.protectionSpace.host.lowercased() == baseURL.host?.lowercased()
         else {
             completionHandler(.performDefaultHandling, nil)

--- a/Open UI/Core/Networking/SocketIOService.swift
+++ b/Open UI/Core/Networking/SocketIOService.swift
@@ -568,7 +568,7 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
         handleDisconnect(reason: reasonStr)
     }
 
-    func urlSession(
+    nonisolated func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void

--- a/Open UI/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/Open UI/Features/Auth/ViewModels/AuthViewModel.swift
@@ -55,6 +55,10 @@ final class AuthViewModel {
     var showCloudflareChallenge: Bool = false
     /// The normalized URL pending connection after a Cloudflare challenge is solved.
     private var pendingCloudflareURL: String?
+    /// Set to true to present the auth proxy WebView sheet (Authelia, Authentik, etc.).
+    var showProxyAuthChallenge: Bool = false
+    /// The normalized URL pending connection after a proxy auth challenge is solved.
+    private var pendingProxyAuthURL: String?
     /// The OAuth provider key selected by the user (e.g. "google", "microsoft").
     /// Set before navigating to `.ssoLogin` so SSOAuthView can load the provider URL directly.
     var selectedSSOProvider: String?
@@ -271,8 +275,12 @@ final class AuthViewModel {
             showCloudflareChallenge = true
             return
         case .proxyAuthRequired:
-            errorMessage = "Could not connect. If your server is behind Cloudflare or a proxy, ensure the app's IP is allowed through. Otherwise, check your network settings."
+            // The server is behind an auth proxy (Authelia, Authentik, Keycloak, etc.).
+            // Show a WKWebView so the user can authenticate through the proxy portal.
+            // Once done, the proxy session cookies are captured and injected into URLSession.
+            pendingProxyAuthURL = normalizedURL
             isConnecting = false
+            showProxyAuthChallenge = true
             return
         case .unhealthy:
             errorMessage = "Server is reachable but not responding correctly."
@@ -941,6 +949,126 @@ final class AuthViewModel {
         pendingCloudflareURL = nil
         isConnecting = false
         errorMessage = "Security check cancelled. Please try again."
+    }
+
+    // MARK: - Auth Proxy Challenge Handling (Authelia, Authentik, Keycloak, etc.)
+
+    /// Called by `ProxyAuthView` when the user has authenticated through the upstream
+    /// proxy portal and we've captured the resulting session cookies.
+    func resumeAfterProxyAuth(_ cookies: [String: String], userAgent: String) {
+        showProxyAuthChallenge = false
+        guard let urlString = pendingProxyAuthURL else {
+            errorMessage = "Could not resume connection after proxy sign-in."
+            pendingProxyAuthURL = nil
+            return
+        }
+
+        logger.info("🔐 Proxy auth completed — injecting \(cookies.count) cookie(s) and resuming connection to \(urlString)")
+
+        // Inject all captured cookies into HTTPCookieStorage.shared so URLSession
+        // sends them automatically on every subsequent request.
+        guard let url = URL(string: urlString), let host = url.host else {
+            errorMessage = "Invalid server URL after proxy sign-in."
+            pendingProxyAuthURL = nil
+            return
+        }
+        for (name, value) in cookies {
+            let cookieProperties: [HTTPCookiePropertyKey: Any] = [
+                .name: name,
+                .value: value,
+                .domain: host,
+                .path: "/",
+                .secure: url.scheme == "https" ? "TRUE" : "FALSE"
+            ]
+            if let cookie = HTTPCookie(properties: cookieProperties) {
+                HTTPCookieStorage.shared.setCookie(cookie)
+            }
+        }
+
+        serverURL = urlString
+        pendingProxyAuthURL = nil
+
+        Task { await connectSkippingProxyCheck(normalizedURL: urlString, proxyAuthCookies: cookies, userAgent: userAgent) }
+    }
+
+    /// Connects to a server directly, skipping the proxy health check.
+    /// Used after a successful proxy auth challenge where the session cookies are already injected.
+    private func connectSkippingProxyCheck(normalizedURL: String, proxyAuthCookies: [String: String], userAgent: String) async {
+        guard let url = URL(string: normalizedURL), url.host != nil else {
+            errorMessage = "Invalid URL after proxy sign-in."
+            return
+        }
+
+        isConnecting = true
+        errorMessage = nil
+
+        // Persist the User-Agent as a custom header so the proxy session cookies
+        // remain valid (some proxies bind sessions to the UA).
+        var customHeaders: [String: String] = [:]
+        if !userAgent.isEmpty {
+            customHeaders["User-Agent"] = userAgent
+        }
+
+        // Persist all proxy auth data in ServerConfig so it survives app restarts.
+        // On next launch, NetworkManager re-injects the cookies from these fields.
+        let config = ServerConfig(
+            name: url.host ?? "Server",
+            url: normalizedURL,
+            apiKey: apiKey.isEmpty ? nil : apiKey,
+            customHeaders: customHeaders,
+            lastConnected: .now,
+            isActive: true,
+            allowSelfSignedCertificates: allowSelfSignedCerts,
+            proxyAuthCookies: proxyAuthCookies,
+            isAuthProxyProtected: true,
+            proxyAuthPortalURL: normalizedURL
+        )
+
+        let client = APIClient(serverConfig: config)
+
+        if !apiKey.isEmpty {
+            client.updateAuthToken(apiKey)
+        }
+
+        // Skip health check — go straight to verifying it's an OpenWebUI instance
+        guard let configResult = await client.verifyAndGetConfig() else {
+            errorMessage = "Server does not appear to be an OpenWebUI instance."
+            isConnecting = false
+            return
+        }
+
+        backendConfig = configResult
+        logger.info("📋 [connectSkippingProxyCheck] Connected to '\(configResult.name ?? "unknown")' at \(normalizedURL)")
+
+        // Replace any old server config so the proxy-auth-enabled config is active.
+        serverConfigStore.removeAllServers()
+        serverConfigStore.addServer(config)
+        dependencies?.refreshServices()
+
+        if !apiKey.isEmpty {
+            do {
+                currentUser = try await client.getCurrentUser()
+                cacheCurrentUser()
+                phase = .authenticated
+                startTokenRefreshTimer()
+                markOnboardingSeen()
+            } catch {
+                logger.warning("API key auth failed after proxy sign-in: \(error.localizedDescription)")
+                phase = .authMethodSelection
+            }
+        } else {
+            phase = .authMethodSelection
+        }
+
+        isConnecting = false
+    }
+
+    /// Called when the user dismisses the proxy auth challenge without completing it.
+    func dismissProxyAuthChallenge() {
+        showProxyAuthChallenge = false
+        pendingProxyAuthURL = nil
+        isConnecting = false
+        errorMessage = "Sign in cancelled. Please try again."
     }
 
     // MARK: - Private Helpers

--- a/Open UI/Features/Auth/Views/ProxyAuthView.swift
+++ b/Open UI/Features/Auth/Views/ProxyAuthView.swift
@@ -1,0 +1,309 @@
+import SwiftUI
+import WebKit
+import os.log
+
+// MARK: - Proxy Auth WebView
+
+/// A WKWebView that loads the server URL and detects when the user has successfully
+/// authenticated through an upstream auth proxy (Authelia, Authentik, Keycloak,
+/// oauth2-proxy, Pangolin, etc.).
+///
+/// The view works by:
+/// 1. Loading the server URL — the proxy will redirect to its login portal
+/// 2. The user authenticates through whatever UI the proxy shows
+/// 3. The proxy redirects back to the app's server URL
+/// 4. We detect arrival back on the server domain and poll until `/health` returns JSON
+/// 5. All session cookies are captured and passed back for injection into URLSession
+struct ProxyAuthWebView: UIViewRepresentable {
+    let serverURL: String
+    /// Called with all captured cookies (name→value) and the webView's User-Agent
+    /// once the proxy auth is detected as complete.
+    let onSuccess: ([String: String], String) -> Void
+    let onFailed: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(serverURL: serverURL, onSuccess: onSuccess, onFailed: onFailed)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        // Use a fresh ephemeral store so stale proxy sessions don't cause silent
+        // auto-login — we want the user to actually go through the proxy portal.
+        // NOTE: We use default() so that any saved passwords / autofill works,
+        // making the experience smooth for the user.
+        config.websiteDataStore = WKWebsiteDataStore.default()
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = true
+
+        // Use a realistic Mobile Safari UA for maximum proxy compatibility
+        webView.customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+            + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+
+        context.coordinator.webView = webView
+
+        if let url = URL(string: serverURL) {
+            webView.load(URLRequest(url: url))
+        }
+
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        let serverURL: String
+        let onSuccess: ([String: String], String) -> Void
+        let onFailed: () -> Void
+        weak var webView: WKWebView?
+
+        private var pollTimer: Timer?
+        private var timeoutTimer: Timer?
+        private var didSucceed = false
+        private var isCheckingHealth = false
+        private let logger = Logger(subsystem: "com.openui", category: "ProxyAuth")
+
+        init(
+            serverURL: String,
+            onSuccess: @escaping ([String: String], String) -> Void,
+            onFailed: @escaping () -> Void
+        ) {
+            self.serverURL = serverURL
+            self.onSuccess = onSuccess
+            self.onFailed = onFailed
+        }
+
+        deinit {
+            pollTimer?.invalidate()
+            timeoutTimer?.invalidate()
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard !didSucceed else { return }
+            guard let currentURL = webView.url else { return }
+
+            logger.debug("ProxyAuth: page finished loading: \(currentURL.absoluteString)")
+
+            // Check if we've landed back on the server domain
+            if isOnServerDomain(currentURL) {
+                logger.info("ProxyAuth: back on server domain, checking if auth succeeded")
+                startPollingForSuccess()
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFail navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            let nsError = error as NSError
+            guard nsError.code != NSURLErrorCancelled else { return }
+            logger.warning("ProxyAuth: navigation failed: \(error.localizedDescription)")
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            // Block further navigation once we've successfully authenticated
+            if didSucceed {
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        // MARK: - Domain Check
+
+        private func isOnServerDomain(_ url: URL) -> Bool {
+            guard let serverHost = URL(string: serverURL)?.host?.lowercased(),
+                  let currentHost = url.host?.lowercased() else { return false }
+            // Match exact host or same base domain (e.g. sub.example.com vs example.com)
+            return currentHost == serverHost || currentHost.hasSuffix(".\(serverHost)")
+        }
+
+        // MARK: - Polling
+
+        /// Poll by probing the server's `/health` endpoint directly from the
+        /// WKWebView via `fetch()`. If it returns JSON with `{"status": true}`,
+        /// the proxy session is active and cookies are valid.
+        private func startPollingForSuccess() {
+            guard !didSucceed, !isCheckingHealth else { return }
+
+            // Start timeout (3 minutes max)
+            if timeoutTimer == nil || !(timeoutTimer?.isValid ?? false) {
+                timeoutTimer = Timer.scheduledTimer(withTimeInterval: 180, repeats: false) { [weak self] _ in
+                    guard let self, !self.didSucceed else { return }
+                    self.pollTimer?.invalidate()
+                    self.logger.warning("ProxyAuth: timed out after 3 minutes")
+                    DispatchQueue.main.async { self.onFailed() }
+                }
+            }
+
+            // Check immediately, then poll every second
+            checkHealthViaFetch()
+            pollTimer?.invalidate()
+            pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                self?.checkHealthViaFetch()
+            }
+        }
+
+        /// Uses WKWebView's `fetch()` to check `/health` — this runs with the webview's
+        /// cookies so it works even before we inject them into URLSession.
+        private func checkHealthViaFetch() {
+            guard !didSucceed, !isCheckingHealth, let webView else { return }
+            isCheckingHealth = true
+
+            let healthURL = serverURL.hasSuffix("/")
+                ? "\(serverURL)health"
+                : "\(serverURL)/health"
+
+            let script = """
+            (async function() {
+                try {
+                    const r = await fetch('\(healthURL)', {
+                        credentials: 'include',
+                        cache: 'no-store'
+                    });
+                    if (!r.ok) return JSON.stringify({ok: false, status: r.status});
+                    const contentType = r.headers.get('content-type') || '';
+                    if (!contentType.includes('application/json')) {
+                        return JSON.stringify({ok: false, status: r.status, html: true});
+                    }
+                    const data = await r.json();
+                    return JSON.stringify({ok: true, status: data.status});
+                } catch(e) {
+                    return JSON.stringify({ok: false, error: e.message});
+                }
+            })()
+            """
+
+            webView.evaluateJavaScript(script) { [weak self] result, error in
+                guard let self else { return }
+                self.isCheckingHealth = false
+
+                guard error == nil, let resultString = result as? String,
+                      let data = resultString.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else { return }
+
+                let isOK = json["ok"] as? Bool ?? false
+                let status = json["status"]
+                let isValidStatus = (status as? Bool) == true || (status as? Int) == 1
+
+                if isOK && isValidStatus {
+                    self.captureSessionAndSucceed()
+                }
+            }
+        }
+
+        // MARK: - Cookie Capture
+
+        private func captureSessionAndSucceed() {
+            guard !didSucceed, let webView else { return }
+            didSucceed = true
+            pollTimer?.invalidate()
+            timeoutTimer?.invalidate()
+
+            logger.info("ProxyAuth: health check passed — capturing cookies")
+
+            WKWebsiteDataStore.default().httpCookieStore.getAllCookies { [weak self, weak webView] cookies in
+                guard let self else { return }
+
+                // Build name→value dictionary of ALL cookies
+                var cookieDict: [String: String] = [:]
+                for cookie in cookies {
+                    cookieDict[cookie.name] = cookie.value
+                }
+
+                self.logger.info("ProxyAuth: captured \(cookieDict.count) cookies")
+
+                // Get the WebView User-Agent
+                webView?.evaluateJavaScript("navigator.userAgent") { [weak self] ua, _ in
+                    let userAgent = (ua as? String) ?? ""
+                    DispatchQueue.main.async {
+                        self?.onSuccess(cookieDict, userAgent)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Proxy Auth Sheet View
+
+/// Full-screen sheet shown when the server is behind an authentication proxy.
+/// Presents a WKWebView so the user can log in through the proxy portal
+/// (Authelia, Authentik, Keycloak, etc.), then captures the session cookies
+/// and resumes the connection automatically.
+struct ProxyAuthView: View {
+    let serverURL: String
+    /// Called with all captured cookies and the webView's User-Agent on success.
+    let onSuccess: ([String: String], String) -> Void
+    let onDismiss: () -> Void
+
+    @State private var isWaiting = true
+    @State private var didFail = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                ProxyAuthWebView(
+                    serverURL: serverURL,
+                    onSuccess: { cookies, userAgent in
+                        isWaiting = false
+                        onSuccess(cookies, userAgent)
+                    },
+                    onFailed: {
+                        isWaiting = false
+                        didFail = true
+                    }
+                )
+                .ignoresSafeArea(edges: .bottom)
+
+                if isWaiting {
+                    VStack(spacing: Spacing.sm) {
+                        HStack(spacing: Spacing.sm) {
+                            ProgressView()
+                                .tint(theme.brandPrimary)
+                            Text("Sign in to continue — your login is being detected automatically.")
+                                .scaledFont(size: 12, weight: .medium)
+                                .foregroundStyle(theme.textSecondary)
+                        }
+                        .padding(.horizontal, Spacing.md)
+                        .padding(.vertical, Spacing.sm)
+                        .background(.ultraThinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                        .padding(.top, Spacing.sm)
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .navigationTitle("Sign In")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onDismiss()
+                    }
+                }
+            }
+            .alert("Sign In Timed Out", isPresented: $didFail) {
+                Button("Try Again") {
+                    didFail = false
+                    isWaiting = true
+                }
+                Button("Cancel", role: .cancel) {
+                    onDismiss()
+                }
+            } message: {
+                Text("The sign-in process took too long. Please try again.")
+            }
+        }
+    }
+}

--- a/Open UI/Features/Auth/Views/ServerConnectionView.swift
+++ b/Open UI/Features/Auth/Views/ServerConnectionView.swift
@@ -376,5 +376,16 @@ struct ServerConnectionView: View {
                 }
             )
         }
+        .fullScreenCover(isPresented: $viewModel.showProxyAuthChallenge) {
+            ProxyAuthView(
+                serverURL: viewModel.serverURL,
+                onSuccess: { cookies, userAgent in
+                    viewModel.resumeAfterProxyAuth(cookies, userAgent: userAgent)
+                },
+                onDismiss: {
+                    viewModel.dismissProxyAuthChallenge()
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
## Problem

Users whose OpenWebUI server is behind a forward-auth proxy (Authelia, Authentik, Keycloak, oauth2-proxy, nginx auth_request, etc.) see this error when trying to connect:

> **Server requires proxy authentication. Check your network settings.**

The app detected the proxy's 302 redirect / 401 response but had no way to complete the challenge, so it just errored out.

## Solution

Implements a WebView-based proxy authentication flow — identical in design to the existing Cloudflare Bot protection handling.

**Flow:**
1. App detects proxy auth (302/307/308 redirect or 401/403 with HTML body)
2. `ProxyAuthView` (WKWebView) is presented fullscreen
3. WKWebView loads the server URL → proxy redirects to its login portal
4. User authenticates in the web view
5. App polls `/health` via JS `fetch()` inside the WebView to detect when back on the server
6. All cookies are captured from `WKHTTPCookieStore` and injected into `HTTPCookieStorage.shared`
7. App proceeds with normal login flow — cookies are sent automatically on all subsequent requests
8. Cookies are persisted in `ServerConfig` and re-injected on every app launch

## Files Changed

| File | Change |
|------|--------|
| `ServerConfig.swift` | Added `isAuthProxyProtected`, `proxyAuthCookies`, `proxyAuthPortalURL` |
| `APIClient.swift` | Detect proxy challenge → surface `.proxyAuthRequired` error |
| `NetworkManager.swift` | Re-inject persisted proxy cookies on startup; fix Swift 6 `@Sendable` |
| `SocketIOService.swift` | Fix Swift 6 `@Sendable` on `urlSession` delegate method |
| `AuthViewModel.swift` | Handle `.proxyAuthRequired`, `resumeAfterProxyAuth()` injects cookies |
| `ServerConnectionView.swift` | Present `ProxyAuthView` as `.fullScreenCover` on proxy challenge |
| `ProxyAuthView.swift` *(new)* | Full WKWebView auth flow with progress banner, timeout, cancel |

## Testing

To test, point the app at an OpenWebUI instance protected by any of:
- **Authelia** (forward-auth)
- **Authentik** (proxy provider)
- **Keycloak** (reverse proxy)  
- **oauth2-proxy**
- **nginx `auth_request`**
- Any proxy that returns a 302 redirect to a login page

The app should now show a sign-in web view instead of the error message.