### PR TITLE
Audio interruption during calls

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -1,0 +1,112 @@
+name: Build IPA
+
+on:
+  workflow_dispatch:
+    inputs:
+      device_udid:
+        description: "Your iPhone UDID (for provisioning profile)"
+        required: false
+
+jobs:
+  build:
+    runs-on: macos-16
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select latest Xcode 16
+        run: |
+          LATEST=$(ls /Applications/ | grep -E 'Xcode_16\.' | sort -V | tail -1)
+          echo "Using: $LATEST"
+          sudo xcode-select -s "/Applications/$LATEST"
+
+      - name: Install certificate and provisioning profile
+        run: |
+          # Create keychain
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+
+          # Install .p12 certificate
+          echo "${{ secrets.APPLE_CERT_P12 }}" | base64 -d > certificate.p12
+          security import certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERT_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/security
+          rm certificate.p12
+
+          # Install provisioning profile
+          echo "${{ secrets.APPLE_PROVISIONING_PROFILE }}" | base64 -d > embedded.mobileprovision
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp embedded.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+          rm embedded.mobileprovision
+
+          # Allow codesigning tools access
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+
+      - name: Resolve Swift Packages
+        run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj" -scheme "Open UI"
+
+      - name: Build Archive
+        run: |
+          xcodebuild archive \
+            -project "Open UI.xcodeproj" \
+            -scheme "Open UI" \
+            -configuration Release \
+            -archivePath "build/OpenUI.xcarchive" \
+            CODE_SIGN_IDENTITY="iPhone Distribution" \
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_DEVELOPMENT_TEAM }}" \
+            PROVISIONING_PROFILE_SPECIFIER="${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}"
+
+      - name: Export IPA
+        run: |
+          cat > ExportOptions.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+            "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>ad-hoc</string>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>compileBitcode</key>
+            <false/>
+            <key>uploadSymbols</key>
+            <false/>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.openui.openui</key>
+              <string>${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}</string>
+              <key>com.openui.openui.OpenUIWidget</key>
+              <string>${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath "build/OpenUI.xcarchive" \
+            -exportPath "build/export" \
+            -exportOptionsPlist ExportOptions.plist
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenUI.ipa
+          path: build/export/*.ipa
+          retention-days: 30
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sideload-${{ github.run_number }}
+          files: build/export/*.ipa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain build.keychain 2>/dev/null || true

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-16
     permissions:
       contents: write
 

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -15,11 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select latest Xcode
+      - name: Select Xcode 26.3
         run: |
-          LATEST=$(ls /Applications/ | grep -E 'Xcode_.*\.app' | sort -V | tail -1)
-          echo "Using: $LATEST"
-          sudo xcode-select -s "/Applications/$LATEST"
+          XC="/Applications/Xcode_26.3.app"
+          if [ ! -d "$XC" ]; then
+            LATEST=$(ls /Applications/ | grep -E 'Xcode_26\.' | sort -V | tail -1)
+            XC="/Applications/$LATEST"
+            echo "Xcode 26.3 not found, using: $LATEST"
+          fi
+          sudo xcode-select -s "$XC"
           xcodebuild -version
 
       - name: Resolve Swift Packages

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-16
+    runs-on: macos-15
     permissions:
       contents: write
 

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -1,4 +1,5 @@
 name: Build IPA
+
 on:
   push:
     branches:
@@ -6,31 +7,45 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-16
+    permissions:
+      contents: write
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Resolve Swift packages
-        run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj"
+      - name: Select latest Xcode 16
+        run: |
+          LATEST=$(ls /Applications/ | grep -E 'Xcode_16\.' | sort -V | tail -1)
+          echo "Using: $LATEST"
+          sudo xcode-select -s "/Applications/$LATEST"
 
-      - name: Build archive (unsigned)
+      - name: Resolve Swift Packages
+        run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj" -scheme "Open UI"
+
+      - name: Build Archive (unsigned)
         run: |
           xcodebuild archive \
             -project "Open UI.xcodeproj" \
             -scheme "Open UI" \
             -configuration Release \
-            -archivePath ./build/OpenRelay.xcarchive \
+            -archivePath "build/OpenUI.xcarchive" \
             CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            AD_HOC_CODE_SIGNING_ALLOWED=YES
 
-      - name: Package as IPA
+      - name: Package IPA
         run: |
-          mkdir -p ./build/Payload
-          cp -r "./build/OpenRelay.xcarchive/Products/Applications/Open UI.app" ./build/Payload/
-          cd ./build
-          zip -r OpenRelay.ipa Payload
+          mkdir -p build/Payload
+          cp -r "build/OpenUI.xcarchive/Products/Applications/Open UI.app" build/Payload/
+          cd build
+          zip -r OpenUI.ipa Payload
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
         with:
-          name: OpenRelay-IPA
-          path: ./build/OpenRelay.ipa
+          name: OpenUI.ipa
+          path: build/OpenUI.ipa
+          retention-days: 30

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -15,11 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select latest Xcode 16
+      - name: Select latest Xcode
         run: |
-          LATEST=$(ls /Applications/ | grep -E 'Xcode_16\.' | sort -V | tail -1)
+          LATEST=$(ls /Applications/ | grep -E 'Xcode_.*\.app' | sort -V | tail -1)
           echo "Using: $LATEST"
           sudo xcode-select -s "/Applications/$LATEST"
+          xcodebuild -version
 
       - name: Resolve Swift Packages
         run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj" -scheme "Open UI"

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -1,112 +1,36 @@
 name: Build IPA
-
 on:
-  workflow_dispatch:
-    inputs:
-      device_udid:
-        description: "Your iPhone UDID (for provisioning profile)"
-        required: false
+  push:
+    branches:
+      - Audio-interruption-during-calls
 
 jobs:
   build:
-    runs-on: macos-16
-    permissions:
-      contents: write
-
+    runs-on: macos-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Select latest Xcode 16
-        run: |
-          LATEST=$(ls /Applications/ | grep -E 'Xcode_16\.' | sort -V | tail -1)
-          echo "Using: $LATEST"
-          sudo xcode-select -s "/Applications/$LATEST"
+      - name: Resolve Swift packages
+        run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj"
 
-      - name: Install certificate and provisioning profile
-        run: |
-          # Create keychain
-          security create-keychain -p "" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "" build.keychain
-          security set-keychain-settings -t 3600 -u build.keychain
-
-          # Install .p12 certificate
-          echo "${{ secrets.APPLE_CERT_P12 }}" | base64 -d > certificate.p12
-          security import certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERT_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/security
-          rm certificate.p12
-
-          # Install provisioning profile
-          echo "${{ secrets.APPLE_PROVISIONING_PROFILE }}" | base64 -d > embedded.mobileprovision
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp embedded.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
-          rm embedded.mobileprovision
-
-          # Allow codesigning tools access
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
-
-      - name: Resolve Swift Packages
-        run: xcodebuild -resolvePackageDependencies -project "Open UI.xcodeproj" -scheme "Open UI"
-
-      - name: Build Archive
+      - name: Build archive (unsigned)
         run: |
           xcodebuild archive \
             -project "Open UI.xcodeproj" \
             -scheme "Open UI" \
             -configuration Release \
-            -archivePath "build/OpenUI.xcarchive" \
-            CODE_SIGN_IDENTITY="iPhone Distribution" \
-            DEVELOPMENT_TEAM="${{ secrets.APPLE_DEVELOPMENT_TEAM }}" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}"
+            -archivePath ./build/OpenRelay.xcarchive \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
 
-      - name: Export IPA
+      - name: Package as IPA
         run: |
-          cat > ExportOptions.plist << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-            "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>ad-hoc</string>
-            <key>uploadBitcode</key>
-            <false/>
-            <key>compileBitcode</key>
-            <false/>
-            <key>uploadSymbols</key>
-            <false/>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>com.openui.openui</key>
-              <string>${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}</string>
-              <key>com.openui.openui.OpenUIWidget</key>
-              <string>${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}</string>
-            </dict>
-          </dict>
-          </plist>
-          EOF
+          mkdir -p ./build/Payload
+          cp -r "./build/OpenRelay.xcarchive/Products/Applications/Open UI.app" ./build/Payload/
+          cd ./build
+          zip -r OpenRelay.ipa Payload
 
-          xcodebuild -exportArchive \
-            -archivePath "build/OpenUI.xcarchive" \
-            -exportPath "build/export" \
-            -exportOptionsPlist ExportOptions.plist
-
-      - name: Upload IPA
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: OpenUI.ipa
-          path: build/export/*.ipa
-          retention-days: 30
-
-      - name: Upload to Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: sideload-${{ github.run_number }}
-          files: build/export/*.ipa
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          security delete-keychain build.keychain 2>/dev/null || true
+          name: OpenRelay-IPA
+          path: ./build/OpenRelay.ipa

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,138 @@
+# Open Relay — Agent Instructions
+
+## Project Overview
+
+Native iOS/iPadOS client for [Open WebUI](https://openwebui.com). 100% SwiftUI, Swift 6, strict concurrency, MVVM architecture. Targets iOS 18.1+.
+
+- **Repo**: `Ichigo3766/Open-Relay`
+- **App Store**: [id6759630325](https://apps.apple.com/app/id6759630325)
+- **License**: GPL
+
+---
+
+## Build & Run
+
+- **Xcode 16.0+** required. Open `Open UI.xcodeproj` (not a workspace).
+- Xcode auto-fetches Swift Package dependencies on first open.
+- Configure signing on the **Open UI** target before running.
+- Select an **iOS 18.1+** simulator or device.
+- No `Package.swift` — all SPM packages are managed inside `.xcodeproj`.
+
+---
+
+## Project Structure
+
+```
+Open UI/                      ← main app target (bundle: com.openui.openui)
+├── App/
+│   └── Open_UIApp.swift      ← @main entry: AppDelegate, scene delegate, RootView
+├── Core/
+│   ├── Extensions/            ← Swift extensions (Date, emoji, timestamps)
+│   ├── Models/                ← Data models (23 files: ChatMessage, Conversation, etc.)
+│   ├── Networking/            ← APIClient, SSEStream, SocketIOService, KeychainService
+│   └── Services/             ← 40 service singletons (TTS, ASR, streaming, etc.)
+├── Features/                  ← Feature modules (14 directories)
+│   ├── Chat/                  ← Core chat UI + ChatViewModel
+│   ├── VoiceCall/             ← CallKit voice calls
+│   ├── Channels/              ← Group chat rooms
+│   ├── Workspace/             ← Models, prompts, skills, tools management
+│   ├── Admin/                 ← Admin console
+│   └── ... (Auth, Settings, Terminal, Calendar, Automations, etc.)
+├── Navigation/
+│   ├── AppRouter.swift        ← @Observable router (NavigationPath + sheets)
+│   └── Route.swift            ← Route enum
+├── Shared/
+│   ├── Components/            ← 49 reusable SwiftUI views
+│   └── Theme/                 ← AppTheme, ColorTokens, Typography, ViewStyles
+├── Open_UI.xcdatamodeld/      ← Core Data model
+├── Info.plist                 ← URL scheme (openui://), shortcuts, background modes
+└── Open UI.entitlements       ← App entitlements
+
+OpenUIWidgets/                  ← widget extension target
+├── OpenUIWidgetsBundle.swift  ← Widget extension entry
+└── *.swift                    ← Lock screen, quick actions, control center widgets
+```
+
+---
+
+## Architecture
+
+### Dependency Injection
+- `AppDependencyContainer` (`@Observable`) is the single DI container, injected via `.environment()` at `RootView`.
+- All services are instantiated once in the container. Server-scoped services (`APIClient`, `SocketIOService`, managers) rebuild on server switch via `configureServicesForActiveServer()`.
+- Views access services through `@Environment(AppDependencyContainer.self)`.
+
+### State Management
+- **`@Observable` macro** (Swift 6) for all view models and containers. No ObservableObject.
+- **`AppRouter`** manages `NavigationPath` for main nav + separate `channelPath` for channels. Sheets use `presentedSheet: Route?`.
+- **`ActiveChatStore`** caches up to 5 `ChatViewModel` instances (LRU eviction). Streaming VMs are never evicted. Shared model/settings cache lives here.
+
+### Networking
+- **SSE** (Server-Sent Events) for streaming chat responses.
+- **Socket.IO** for real-time channels, notifications.
+- **REST** via `APIClient` for all other API calls.
+- Auth token stored in Keychain, scoped per server URL.
+
+### ML / On-Device
+- **MLX** for on-device TTS (Kokoro) and ASR (Qwen3).
+- `Memory.cacheLimit = 20 MB` set at launch to prevent GPU memory spike.
+- All MLX models **must unload before backgrounding** (Metal GPU forbidden in background on iOS < 26). See `Open_UIApp.swift` scenePhase handler.
+
+---
+
+## Key Conventions
+
+### Navigation
+- Push via `router.navigate(to:)`, pop via `router.goBack()`, sheets via `router.presentSheet()`.
+- Voice call is a `fullScreenCover` managed by `router.presentVoiceCall()` / `minimizeVoiceCall()` / `dismissVoiceCall()`.
+- Deep links use `openui://` scheme (handled in `handleDeepLink`). Widget actions use `NotificationCenter` posts.
+
+### Theming
+- Custom `.themed(with:accessibility:)` view modifier applies `AppTheme` + `AccessibilityManager`.
+- Color scheme driven by `AppearanceManager.resolvedColorScheme` (supports Default, Dark, OLED, Tinted).
+- Accessibility: independent text scaling for messages, titles, and UI elements.
+
+### Backgrounding
+- On `.inactive`/`.background`: stop TTS, unload Kokoro, pause ASR, run storage cleanup.
+- On `.active`: process pending shortcut actions, reconnect socket, health check.
+- Background tasks registered: `com.openui.streaming`, `com.openui.asr.transcription`.
+
+### Auth Flow
+- Phase-based state machine in `AuthViewModel`: `.serverConnection` → `.restoringSession` → `.authMethodSelection` → login/SSO/LDAP → `.authenticated`.
+- Multi-account per server. Token stored per-server in Keychain.
+- Server switch calls `router.resetAll()` + rebuilds all server-scoped services.
+
+### Notifications
+- Cross-process communication with widgets via `UserDefaults(suiteName: appGroupId)` and `NotificationCenter`.
+- Notification tap opens specific chat via `NotificationService.shared.onOpenChat`.
+
+---
+
+## Important Gotchas
+
+1. **No `&&` in PowerShell** — use `; if ($?) { }` or `workdir` parameter.
+2. **`Info.plist` is excluded** from file-system sync in pbxproj. Edit only through Xcode or directly in the file.
+3. **Scene delegate, not app delegate**, handles shortcut items (`UIApplicationShortcutItems` in Info.plist). Quick actions route through `ShortcutSceneDelegate` → `AppDelegate.pendingShortcutAction` → `scenePhase == .active` handler.
+4. **AVAudioSession** must be configured before any `WKWebView` is created (affects silent switch behavior for inline HTML previews).
+5. **Cloudflare-protected servers** require CF cookies on avatar fetches. `ImageCacheService` must be configured with CF headers separately from `APIClient`.
+6. **SwiftUI `@ObservationIgnored`** is used on internal storage dicts to prevent AttributeGraph cycles during body evaluation.
+7. **iPad vs iPhone**: `horizontalSizeClass == .regular` branches to `iPadMainChatView` (persistent sidebar) vs `MainChatView`. Always test both.
+
+---
+
+## Testing
+
+- No automated test suite exists.
+- PR template requires manual testing on **both** iPhone and iPad devices/simulators.
+- Verify no new build warnings.
+
+---
+
+## PR Checklist (from `.github/pull_request_template.md`)
+
+- [ ] Tested on device (iPhone)
+- [ ] Tested on device (iPad) — if relevant
+- [ ] Tested on iOS Simulator
+- [ ] Build succeeds with no warnings added
+- [ ] No regressions in related features
+- [ ] Screenshots/recording for UI changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## v4.5 — May 15, 2026
-
-### What's New
-- Added a "save as permanent" button to temporary chats
-- Images embedded directly in responses now display inline — tap to view fullscreen with pinch-to-zoom, or hold to save to Photos or share
-
-### Improvements
-- Significantly reduced false "server disconnected" alerts
-- Returning to the app from the background should reconnect instantly
-- Added a subtle haptic when a response finishes streaming
-
-### Bug Fixes
-- Fixed a race condition where streaming auto-scroll would randomly disengage mid-response.
-
-
 ## v4.4 — May 14, 2026
 
 ### What's New

--- a/Open UI.xcodeproj/project.pbxproj
+++ b/Open UI.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 4.5;
+				MARKETING_VERSION = 4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openui.openui.OpenUIWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -381,7 +381,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 4.5;
+				MARKETING_VERSION = 4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openui.openui.OpenUIWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -550,7 +550,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.5;
+				MARKETING_VERSION = 4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openui.openui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -598,7 +598,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.5;
+				MARKETING_VERSION = 4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openui.openui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Open UI/App/Open_UIApp.swift
+++ b/Open UI/App/Open_UIApp.swift
@@ -134,12 +134,6 @@ struct Open_UIApp: App {
                 .themed(with: dependencies.appearanceManager, accessibility: dependencies.accessibilityManager)
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
-                        // Notify connection monitor that the app is in the foreground.
-                        // This triggers an immediate health check + socket reconnect,
-                        // cancelling any pending backoff timer so recovery is instant.
-                        dependencies.connectionMonitor.markAppForeground()
-                        dependencies.socketService?.resetBackoffAndReconnect()
-
                         // Process pending actions after a short delay so that
                         // MainChatView / iPadMainChatView have time to mount
                         // their .onReceive handlers before we post notifications.
@@ -159,12 +153,6 @@ struct Open_UIApp: App {
                         }
                     }
                     if newPhase == .inactive || newPhase == .background {
-                        // Notify connection monitor + socket that we're backgrounding.
-                        // Suppresses false "server down" overlays caused by the OS
-                        // suspending network activity and cancels reconnect timers
-                        // that would waste battery in the background.
-                        dependencies.connectionMonitor.markAppBackground()
-                        dependencies.socketService?.markAppBackground()
                         // Stop Kokoro TTS and unload model before backgrounding to prevent
                         // Metal GPU crash (kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted).
                         // .inactive fires before .background, giving us time to release GPU resources.

--- a/Open UI/Core/Networking/APIClient.swift
+++ b/Open UI/Core/Networking/APIClient.swift
@@ -42,22 +42,6 @@ final class APIClient: @unchecked Sendable {
         }
     }
 
-    /// Fast health check with an explicit timeout.
-    /// Used by `ServerConnectionMonitor` to avoid a 30 s stalled request
-    /// blocking the `immediateCheckInFlight` flag and missing real failures.
-    func checkHealthFast(timeout: TimeInterval = 8) async -> Bool {
-        do {
-            let (_, response) = try await network.requestRaw(
-                path: "/health",
-                authenticated: false,
-                timeout: timeout
-            )
-            return response.statusCode == 200
-        } catch {
-            return false
-        }
-    }
-
     /// Checks server health with proxy detection. Also detects HTTP→HTTPS redirects
     /// and returns the final HTTPS URL so the caller can update the stored server URL.
     func checkHealthWithProxyDetection() async -> HealthCheckResult {
@@ -710,81 +694,6 @@ final class APIClient: @unchecked Sendable {
 
     func getConversation(id: String) async throws -> Conversation {
         let (data, _) = try await network.requestRaw(path: "/api/v1/chats/\(id)")
-
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw APIError.responseDecoding(
-                underlying: NSError(
-                    domain: "APIError", code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Expected chat object"]
-                ),
-                data: data
-            )
-        }
-
-        return parseFullConversation(json)
-    }
-
-    /// Creates a new permanent chat on the server using the full history payload.
-    /// Used to convert a temporary (local-only) chat into a persisted one.
-    /// Sends the existing local chat ID, title, model, history tree, and flat
-    /// messages array in a single `POST /api/v1/chats/new` call — matching the
-    /// web UI's "save temp chat" behaviour exactly.
-    func createConversationWithHistory(
-        id: String,
-        title: String,
-        model: String?,
-        history: MessageHistory,
-        messages: [ChatMessage],
-        chatParams: ChatAdvancedParams? = nil,
-        folderId: String? = nil
-    ) async throws -> Conversation {
-        // Build flat messages array
-        let flatMessages = history.createMessagesList()
-        let messagesArray: [[String: Any]] = flatMessages.map { msg in
-            var dict: [String: Any] = [
-                "id": msg.id,
-                "parentId": (msg.parentId as Any?) ?? NSNull(),
-                "childrenIds": [String](),
-                "role": msg.role.rawValue,
-                "content": msg.content,
-                "timestamp": Int(msg.timestamp.timeIntervalSince1970)
-            ]
-            if msg.role == .assistant {
-                if let m = msg.model { dict["model"] = m; dict["modelName"] = m }
-                dict["modelIdx"] = 0
-                dict["done"] = true
-            }
-            if msg.role == .user, let m = model { dict["models"] = [m] }
-            if let usage = msg.usage, !usage.isEmpty { dict["usage"] = usage }
-            if !msg.followUps.isEmpty { dict["followUps"] = msg.followUps }
-            return dict
-        }
-
-        // Build params dict
-        var paramsDict: [String: Any] = chatParams?.toRequestParams() ?? [:]
-        if let sp = chatParams?.systemPrompt, !sp.trimmingCharacters(in: .whitespaces).isEmpty {
-            paramsDict["system"] = sp
-        }
-
-        let chatData: [String: Any] = [
-            "id": id,
-            "title": title,
-            "models": model.map { [$0] } ?? [],
-            "params": paramsDict,
-            "history": history.toServerDict(),
-            "messages": messagesArray,
-            "tags": [String](),
-            "timestamp": Int(Date().timeIntervalSince1970 * 1000)
-        ]
-
-        var body: [String: Any] = ["chat": chatData]
-        if let folderId { body["folder_id"] = folderId }
-
-        let (data, _) = try await network.requestRaw(
-            path: "/api/v1/chats/new",
-            method: .post,
-            body: try JSONSerialization.data(withJSONObject: body)
-        )
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw APIError.responseDecoding(

--- a/Open UI/Core/Networking/SocketIOService.swift
+++ b/Open UI/Core/Networking/SocketIOService.swift
@@ -96,11 +96,6 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
     /// Whether auto-reconnect is enabled. Disabled on intentional disconnect.
     private var autoReconnectEnabled = true
 
-    /// Whether the app is currently in the background.
-    /// While backgrounded, we pause the reconnect backoff timer and reconnect
-    /// immediately when the app returns to the foreground.
-    private var isAppInBackground = false
-
     /// Maximum number of reconnection attempts before giving up.
     /// After this, the socket stays disconnected until manually reconnected.
     private let maxReconnectAttempts = 50
@@ -133,37 +128,6 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
         self.serverConfig = serverConfig
         self.authToken = authToken
         super.init()
-    }
-
-    // MARK: - App Lifecycle
-
-    /// Called when the app moves to the background.
-    /// Cancels pending reconnect timers to prevent wasted attempts while
-    /// the OS has us suspended.
-    func markAppBackground() {
-        isAppInBackground = true
-        // Cancel any pending reconnect timer — we'll reconnect immediately on foreground
-        DispatchQueue.main.async { [weak self] in
-            self?.reconnectTimer?.invalidate()
-            self?.reconnectTimer = nil
-        }
-    }
-
-    /// Called when the app returns to the foreground.
-    /// If the socket is disconnected, reconnects immediately instead of waiting
-    /// out the remaining backoff delay.
-    func resetBackoffAndReconnect() {
-        isAppInBackground = false
-        // Cancel any pending reconnect timer
-        DispatchQueue.main.async { [weak self] in
-            self?.reconnectTimer?.invalidate()
-            self?.reconnectTimer = nil
-        }
-        // Reset backoff counter so the next reconnect starts from attempt 0
-        reconnectAttempt = 0
-        guard !isConnected, !isConnecting, autoReconnectEnabled else { return }
-        reconnectCount += 1
-        connect()
     }
 
     // MARK: - Connection
@@ -1023,17 +987,7 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
     }
 
     private func scheduleReconnect() {
-        // Invalidate on main thread immediately to prevent the race where a
-        // rapid second disconnect fires before the first async block runs.
-        if Thread.isMainThread {
-            reconnectTimer?.invalidate()
-            reconnectTimer = nil
-        } else {
-            DispatchQueue.main.sync { [weak self] in
-                self?.reconnectTimer?.invalidate()
-                self?.reconnectTimer = nil
-            }
-        }
+        reconnectTimer?.invalidate()
 
         guard autoReconnectEnabled else {
             connectionState = .disconnected
@@ -1051,13 +1005,6 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
 
         connectionState = .reconnecting(attempt: reconnectAttempt)
 
-        // If the app is backgrounded, don't schedule a timer that won't fire reliably.
-        // resetBackoffAndReconnect() will connect immediately when foreground returns.
-        if isAppInBackground {
-            logger.info("App in background — deferring reconnect until foreground")
-            return
-        }
-
         let jitter = Double.random(in: 0...0.5)
         let delay = min(
             baseReconnectDelay * pow(2.0, Double(min(reconnectAttempt - 1, 5))) + jitter,
@@ -1067,8 +1014,7 @@ final class SocketIOService: NSObject, @unchecked Sendable, URLSessionWebSocketD
         logger.info("Scheduling reconnect in \(String(format: "%.1f", delay))s (attempt \(self.reconnectAttempt)/\(self.maxReconnectAttempts))")
 
         DispatchQueue.main.async { [weak self] in
-            guard let self, self.autoReconnectEnabled, !self.isConnected, !self.isConnecting else { return }
-            self.reconnectTimer = Timer.scheduledTimer(
+            self?.reconnectTimer = Timer.scheduledTimer(
                 withTimeInterval: delay,
                 repeats: false
             ) { [weak self] _ in

--- a/Open UI/Core/Services/AudioSessionManager.swift
+++ b/Open UI/Core/Services/AudioSessionManager.swift
@@ -44,7 +44,9 @@ final class AudioSessionManager {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            self?.handleInterruption(notification)
+            MainActor.assumeIsolated {
+                self?.handleInterruption(notification)
+            }
         }
 
         // 2. Route change notification (CarPlay connect/disconnect, volume knob)
@@ -53,7 +55,9 @@ final class AudioSessionManager {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            self?.handleRouteChange(notification)
+            MainActor.assumeIsolated {
+                self?.handleRouteChange(notification)
+            }
         }
 
         // 3. Media services reset (rare but should be handled)
@@ -62,8 +66,10 @@ final class AudioSessionManager {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.logger.info("Media services were reset — reactivating session")
-            self?.reactivateSession()
+            MainActor.assumeIsolated {
+                self?.logger.info("Media services were reset — reactivating session")
+                self?.reactivateSession()
+            }
         }
 
         logger.info("AudioSessionManager: listeners installed")
@@ -193,7 +199,7 @@ final class AudioSessionManager {
 
     /// Configures the audio session through the serial queue to prevent races.
     /// Call this instead of calling setCategory/setActive directly from services.
-    func configureSession(_ configuration: (AVAudioSession) throws -> Void) {
+    func configureSession(_ configuration: @escaping (AVAudioSession) throws -> Void) {
         Task.detached {
             await self.sessionQueue.configure(configuration)
         }

--- a/Open UI/Core/Services/AudioSessionManager.swift
+++ b/Open UI/Core/Services/AudioSessionManager.swift
@@ -49,9 +49,7 @@ final class AudioSessionManager {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            Task { @MainActor [weak self] in
-                self?.handleInterruption(notification)
-            }
+            self?.handleInterruption(notification)
         }
 
         // 2. Route change notification (CarPlay connect/disconnect, volume knob)
@@ -60,9 +58,7 @@ final class AudioSessionManager {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            Task { @MainActor [weak self] in
-                self?.handleRouteChange(notification)
-            }
+            self?.handleRouteChange(notification)
         }
 
         // 3. Media services reset (rare but should be handled)
@@ -72,17 +68,17 @@ final class AudioSessionManager {
             queue: .main
         ) { [weak self] _ in
             self?.logger.info("Media services were reset — reactivating session")
-            Task { @MainActor [weak self] in
-                self?.reactivateSession()
-            }
+            self?.reactivateSession()
         }
 
         // 4. Intercept volume changes from CarPlay / remote controls.
         // Returning .success prevents the system from treating the volume
         // change as an audio interruption that deactivates our session.
         // The actual volume still changes — we just prevent session deactivation.
-        remoteCommandCenter.changePlaybackVolumeCommand.addTarget { [weak self] _ in
-            return .success
+        if #available(iOS 18.1, *) {
+            remoteCommandCenter.changePlaybackVolumeCommand.addTarget { [weak self] _ in
+                return .success
+            }
         }
 
         logger.info("AudioSessionManager: listeners installed")
@@ -103,7 +99,9 @@ final class AudioSessionManager {
         }
 
         // Remove volume command target
-        remoteCommandCenter.changePlaybackVolumeCommand.removeTarget()
+        if #available(iOS 18.1, *) {
+            remoteCommandCenter.changePlaybackVolumeCommand.removeTarget()
+        }
 
         logger.info("AudioSessionManager: listeners removed")
     }
@@ -165,14 +163,14 @@ final class AudioSessionManager {
               let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt else { return }
 
         let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
-        logger.info("Audio route changed: \(reason?.rawValue ?? "unknown")")
+        logger.info("Audio route changed: \(reason?.rawValue ?? 0)")
 
         switch reason {
-        case .volumeChanged:
+        case AVAudioSession.RouteChangeReason.volumeChanged?:
             // CarPlay volume knob — reactivate to prevent session deactivation
             if isVoiceCallActive {
                 logger.info("Volume changed during voice call — reactivating session")
-                reactivateSession()
+                self.reactivateSession()
             }
 
         case .newDeviceAvailable:
@@ -203,15 +201,17 @@ final class AudioSessionManager {
     /// Re-activates the audio session after an interruption or route change.
     /// Uses the serial queue to avoid racing with other session configuration.
     private func reactivateSession() {
-        sessionQueue.configure { session in
-            // Re-activate with current category (don't change category, just activate)
-            try? session.setActive(true)
-            // Re-apply output override for CarPlay safety
-            let isCarPlayOrHFP = session.currentRoute.outputs.contains { output in
-                output.portType == .carAudio || output.portType == .bluetoothHFP
-            }
-            if !isCarPlayOrHFP {
-                try? session.overrideOutputAudioPort(.speaker)
+        Task.detached {
+            await self.sessionQueue.configure { session in
+                // Re-activate with current category (don't change category, just activate)
+                try? session.setActive(true)
+                // Re-apply output override for CarPlay safety
+                let isCarPlayOrHFP = session.currentRoute.outputs.contains { output in
+                    output.portType == .carAudio || output.portType == .bluetoothHFP
+                }
+                if !isCarPlayOrHFP {
+                    try? session.overrideOutputAudioPort(.speaker)
+                }
             }
         }
     }
@@ -221,7 +221,9 @@ final class AudioSessionManager {
     /// Configures the audio session through the serial queue to prevent races.
     /// Call this instead of calling setCategory/setActive directly from services.
     func configureSession(_ configuration: (AVAudioSession) throws -> Void) {
-        sessionQueue.configure(configuration)
+        Task.detached {
+            await self.sessionQueue.configure(configuration)
+        }
     }
 }
 

--- a/Open UI/Core/Services/AudioSessionManager.swift
+++ b/Open UI/Core/Services/AudioSessionManager.swift
@@ -1,0 +1,243 @@
+import Foundation
+import AVFoundation
+import MediaPlayer
+import os.log
+
+/// Centralized AVAudioSession manager with interruption handling, route change
+/// recovery, and CarPlay volume-change interception.
+///
+/// Problem solved: CarPlay volume knob changes trigger an implicit audio
+/// interruption. Without handling, iOS deactivates our session and resumes
+/// background media (Spotify, Apple Music, etc.). This manager:
+/// 1. Listens for interruptions and reactivates the session when they end
+/// 2. Listens for route changes and re-activates the session on .volumeChanged
+/// 3. Intercepts MPRemoteCommandCenter volume changes to prevent interruption
+/// 4. Provides a serial actor to prevent concurrent setCategory/setActive calls
+@MainActor
+final class AudioSessionManager {
+
+    private let logger = Logger(subsystem: "com.openui", category: "AudioSession")
+
+    /// Serial actor to prevent concurrent audio session reconfiguration.
+    /// Multiple services (TTS, STT, VoiceCall) call setCategory/setActive independently.
+    /// This actor ensures they execute sequentially, preventing race conditions.
+    private let sessionQueue = AudioSessionQueue()
+
+    /// Whether we're in an active voice call (affects deactivation behavior).
+    private var isVoiceCallActive: Bool = false
+
+    /// Callback fired when an interruption ends and playback should resume.
+    var onInterruptionEnded: (() -> Void)?
+
+    /// Callback fired when audio route changes (e.g., CarPlay connects/disconnects).
+    var onRouteChanged: (() -> Void)?
+
+    /// Notification observers (stored for cleanup).
+    private var interruptionObserver: Any?
+    private var routeChangeObserver: Any?
+    private var mediaServicesResetObserver: Any?
+
+    /// MPRemoteCommandCenter for intercepting volume commands.
+    private let remoteCommandCenter = MPRemoteCommandCenter.shared()
+
+    // MARK: - Lifecycle
+
+    func startListening() {
+        // 1. Interruption notification
+        interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor [weak self] in
+                self?.handleInterruption(notification)
+            }
+        }
+
+        // 2. Route change notification (CarPlay connect/disconnect, volume knob)
+        routeChangeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor [weak self] in
+                self?.handleRouteChange(notification)
+            }
+        }
+
+        // 3. Media services reset (rare but should be handled)
+        mediaServicesResetObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.logger.info("Media services were reset — reactivating session")
+            Task { @MainActor [weak self] in
+                self?.reactivateSession()
+            }
+        }
+
+        // 4. Intercept volume changes from CarPlay / remote controls.
+        // Returning .success prevents the system from treating the volume
+        // change as an audio interruption that deactivates our session.
+        // The actual volume still changes — we just prevent session deactivation.
+        remoteCommandCenter.changePlaybackVolumeCommand.addTarget { [weak self] _ in
+            return .success
+        }
+
+        logger.info("AudioSessionManager: listeners installed")
+    }
+
+    func stopListening() {
+        if let obs = interruptionObserver {
+            NotificationCenter.default.removeObserver(obs)
+            interruptionObserver = nil
+        }
+        if let obs = routeChangeObserver {
+            NotificationCenter.default.removeObserver(obs)
+            routeChangeObserver = nil
+        }
+        if let obs = mediaServicesResetObserver {
+            NotificationCenter.default.removeObserver(obs)
+            mediaServicesResetObserver = nil
+        }
+
+        // Remove volume command target
+        remoteCommandCenter.changePlaybackVolumeCommand.removeTarget()
+
+        logger.info("AudioSessionManager: listeners removed")
+    }
+
+    // MARK: - Voice Call Lifecycle
+
+    /// Called when a voice call starts. Prevents `.notifyOthersOnDeactivation` during call.
+    func voiceCallStarted() {
+        isVoiceCallActive = true
+    }
+
+    /// Called when a voice call ends.
+    func voiceCallEnded() {
+        isVoiceCallActive = false
+    }
+
+    /// Whether TTS should use `.notifyOthersOnDeactivation` on stop.
+    /// Returns `false` during voice calls to prevent Spotify/music from resuming
+    /// when TTS naturally completes between listen/speak cycles.
+    var shouldNotifyOthersOnDeactivation: Bool {
+        !isVoiceCallActive
+    }
+
+    // MARK: - Interruption Handling
+
+    private func handleInterruption(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+
+        switch type {
+        case .began:
+            logger.info("Audio interruption began")
+            // Interruption began (e.g., phone call, CarPlay volume change misinterpreted).
+            // TTS should pause, not stop. The onComplete callback won't fire.
+
+        case .ended:
+            logger.info("Audio interruption ended")
+            guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else { return }
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+
+            if options.contains(.shouldResume) {
+                // Resume playback after interruption ends.
+                // This is the key fix: after CarPlay volume change, we reactivate
+                // the session instead of letting background media take over.
+                reactivateSession()
+                onInterruptionEnded?()
+            }
+
+        @unknown default:
+            break
+        }
+    }
+
+    // MARK: - Route Change Handling
+
+    private func handleRouteChange(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt else { return }
+
+        let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
+        logger.info("Audio route changed: \(reason?.rawValue ?? "unknown")")
+
+        switch reason {
+        case .volumeChanged:
+            // CarPlay volume knob — reactivate to prevent session deactivation
+            if isVoiceCallActive {
+                logger.info("Volume changed during voice call — reactivating session")
+                reactivateSession()
+            }
+
+        case .newDeviceAvailable:
+            // New audio device connected (e.g., CarPlay, BT headset)
+            onRouteChanged?()
+
+        case .oldDeviceUnavailable:
+            // Audio device disconnected
+            onRouteChanged?()
+
+        case .categoryChange:
+            // Category was changed by something else — reassert our configuration
+            if isVoiceCallActive {
+                reactivateSession()
+            }
+
+        case .override:
+            // Output port override changed — re-apply routing
+            onRouteChanged?()
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Session Reactivation
+
+    /// Re-activates the audio session after an interruption or route change.
+    /// Uses the serial queue to avoid racing with other session configuration.
+    private func reactivateSession() {
+        sessionQueue.configure { session in
+            // Re-activate with current category (don't change category, just activate)
+            try? session.setActive(true)
+            // Re-apply output override for CarPlay safety
+            let isCarPlayOrHFP = session.currentRoute.outputs.contains { output in
+                output.portType == .carAudio || output.portType == .bluetoothHFP
+            }
+            if !isCarPlayOrHFP {
+                try? session.overrideOutputAudioPort(.speaker)
+            }
+        }
+    }
+
+    // MARK: - Serial Configuration
+
+    /// Configures the audio session through the serial queue to prevent races.
+    /// Call this instead of calling setCategory/setActive directly from services.
+    func configureSession(_ configuration: (AVAudioSession) throws -> Void) {
+        sessionQueue.configure(configuration)
+    }
+}
+
+// MARK: - Serial Actor for Audio Session Configuration
+
+/// Ensures setCategory/setActive calls execute one at a time.
+/// Without this, concurrent calls from TTS/STT/VoiceCall can cause the session
+/// to end up in an inconsistent state.
+actor AudioSessionQueue {
+
+    func configure(_ configuration: (AVAudioSession) throws -> Void) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try configuration(session)
+        } catch {
+            // Log but don't propagate — individual services handle their own errors
+        }
+    }
+}

--- a/Open UI/Core/Services/AudioSessionManager.swift
+++ b/Open UI/Core/Services/AudioSessionManager.swift
@@ -1,18 +1,16 @@
 import Foundation
 import AVFoundation
-import MediaPlayer
 import os.log
 
-/// Centralized AVAudioSession manager with interruption handling, route change
+   /// Centralized AVAudioSession manager with interruption handling, route change
 /// recovery, and CarPlay volume-change interception.
 ///
 /// Problem solved: CarPlay volume knob changes trigger an implicit audio
 /// interruption. Without handling, iOS deactivates our session and resumes
 /// background media (Spotify, Apple Music, etc.). This manager:
 /// 1. Listens for interruptions and reactivates the session when they end
-/// 2. Listens for route changes and re-activates the session on .volumeChanged
-/// 3. Intercepts MPRemoteCommandCenter volume changes to prevent interruption
-/// 4. Provides a serial actor to prevent concurrent setCategory/setActive calls
+/// 2. Listens for route changes and re-activates the session on device change
+/// 3. Provides a serial actor to prevent concurrent setCategory/setActive calls
 @MainActor
 final class AudioSessionManager {
 
@@ -36,9 +34,6 @@ final class AudioSessionManager {
     private var interruptionObserver: Any?
     private var routeChangeObserver: Any?
     private var mediaServicesResetObserver: Any?
-
-    /// MPRemoteCommandCenter for intercepting volume commands.
-    private let remoteCommandCenter = MPRemoteCommandCenter.shared()
 
     // MARK: - Lifecycle
 
@@ -71,16 +66,6 @@ final class AudioSessionManager {
             self?.reactivateSession()
         }
 
-        // 4. Intercept volume changes from CarPlay / remote controls.
-        // Returning .success prevents the system from treating the volume
-        // change as an audio interruption that deactivates our session.
-        // The actual volume still changes — we just prevent session deactivation.
-        if #available(iOS 18.1, *) {
-            remoteCommandCenter.changePlaybackVolumeCommand.addTarget { [weak self] _ in
-                return .success
-            }
-        }
-
         logger.info("AudioSessionManager: listeners installed")
     }
 
@@ -96,11 +81,6 @@ final class AudioSessionManager {
         if let obs = mediaServicesResetObserver {
             NotificationCenter.default.removeObserver(obs)
             mediaServicesResetObserver = nil
-        }
-
-        // Remove volume command target
-        if #available(iOS 18.1, *) {
-            remoteCommandCenter.changePlaybackVolumeCommand.removeTarget()
         }
 
         logger.info("AudioSessionManager: listeners removed")
@@ -166,13 +146,6 @@ final class AudioSessionManager {
         logger.info("Audio route changed: \(reason?.rawValue ?? 0)")
 
         switch reason {
-        case AVAudioSession.RouteChangeReason.volumeChanged?:
-            // CarPlay volume knob — reactivate to prevent session deactivation
-            if isVoiceCallActive {
-                logger.info("Volume changed during voice call — reactivating session")
-                self.reactivateSession()
-            }
-
         case .newDeviceAvailable:
             // New audio device connected (e.g., CarPlay, BT headset)
             onRouteChanged?()

--- a/Open UI/Core/Services/CallKitManager.swift
+++ b/Open UI/Core/Services/CallKitManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CallKit
+import MediaPlayer
 import os.log
 
 /// Manages CallKit integration for native iOS call UI during voice calls.

--- a/Open UI/Core/Services/DependencyContainer.swift
+++ b/Open UI/Core/Services/DependencyContainer.swift
@@ -230,6 +230,9 @@ final class AppDependencyContainer: ServiceContainer {
     /// CallKit manager for native call UI.
     let callKitManager = CallKitManager()
 
+    /// Centralized audio session manager with interruption/route-change handling.
+    let audioSessionManager = AudioSessionManager()
+
     /// Audio recording service for voice notes.
     let audioRecordingService = AudioRecordingService()
 
@@ -294,6 +297,8 @@ final class AppDependencyContainer: ServiceContainer {
         authViewModel.dependencies = self
         // Models load on-demand when first needed — no startup preloading
         startConnectionMonitor()
+        // Start audio session listeners (interruption, route change, volume interception)
+        audioSessionManager.startListening()
     }
 
     /// Rebuilds the API client and socket service for the currently
@@ -421,13 +426,15 @@ final class AppDependencyContainer: ServiceContainer {
             return VoiceCallViewModel(
                 serverSpeechService: serverSpeechRecognitionService,
                 ttsService: textToSpeechService,
-                callKitManager: callKitManager
+                callKitManager: callKitManager,
+                audioSessionManager: audioSessionManager
             )
         } else {
             return VoiceCallViewModel(
                 speechService: speechRecognitionService,
                 ttsService: textToSpeechService,
-                callKitManager: callKitManager
+                callKitManager: callKitManager,
+                audioSessionManager: audioSessionManager
             )
         }
     }

--- a/Open UI/Core/Services/HapticService.swift
+++ b/Open UI/Core/Services/HapticService.swift
@@ -102,14 +102,6 @@ enum Haptics {
         softGenerator.prepare()
     }
 
-    /// Plays a haptic when the response stream fully drains and completes.
-    /// Respects the same `streamingHaptics` user preference as `streamingTick()`.
-    static func streamingComplete() {
-        guard UserDefaults.standard.object(forKey: "streamingHaptics") as? Bool ?? true else { return }
-        lightGenerator.impactOccurred(intensity: 0.8)
-        lightGenerator.prepare()
-    }
-
     // Private throttle state for streaming haptic.
     // @MainActor isolation on the enum ensures thread-safe access.
     private static var _lastStreamingTime: CFAbsoluteTime = 0

--- a/Open UI/Core/Services/ServerConnectionMonitor.swift
+++ b/Open UI/Core/Services/ServerConnectionMonitor.swift
@@ -28,17 +28,6 @@ enum ServerConnectionState: Equatable, Sendable {
 ///
 /// Exposes an `@Observable` `connectionState` that the UI overlay reads,
 /// and auto-reconnects the Socket.IO service when the server comes back.
-///
-/// Key reliability behaviours:
-/// - **2 consecutive failures** required before declaring `.serverDown`
-///   (eliminates false positives from a single slow/timed-out request).
-/// - **Background suppression**: while the app is backgrounded, transient
-///   network failures are ignored. Only NWPathMonitor internet loss
-///   (which is reliable in the background) can flip the state.
-/// - **Fast foreground recovery**: immediately health-checks + socket-reconnects
-///   on app foreground without waiting for the next poll cycle.
-/// - **8 s health timeout**: prevents a 30 s stalled request from blocking
-///   `immediateCheckInFlight` and missing real failures.
 @Observable
 final class ServerConnectionMonitor: @unchecked Sendable {
     // MARK: - Observable State
@@ -53,7 +42,7 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     var reconnectAttempt: Int = 0
 
     /// Whether the disconnect overlay should be visible.
-    /// Uses a debounce so transient blips don't flash the overlay.
+    /// Uses a debounce so transient blips (<1.5s) don't flash the overlay.
     var isShowingOverlay: Bool = false
 
     // MARK: - Private State
@@ -67,19 +56,11 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     /// Whether the device network path is satisfied (has internet).
     @ObservationIgnored private var isNetworkAvailable: Bool = true
 
-    /// Whether the app is currently in the background.
-    /// While true, transient HTTP failures are suppressed — only NWPathMonitor
-    /// internet loss (reliable in the background) can change the state.
-    @ObservationIgnored private var isAppInBackground: Bool = false
-
     /// The polling task that periodically checks /health.
     @ObservationIgnored private var healthPollTask: Task<Void, Never>?
 
     /// The debounce task for showing/hiding the overlay.
     @ObservationIgnored private var debounceTask: Task<Void, Never>?
-
-    /// Pending foreground-return work: health check + socket reconnect.
-    @ObservationIgnored private var foregroundTask: Task<Void, Never>?
 
     /// Weak reference to the API client for health checks.
     @ObservationIgnored private weak var apiClient: APIClient?
@@ -93,16 +74,10 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     /// Flag to coalesce rapid immediate-check requests.
     @ObservationIgnored private var immediateCheckInFlight = false
 
-    /// Consecutive health check failure counter.
-    /// We require `failureThreshold` consecutive failures before declaring
-    /// the server down. A single slow or dropped request is not a failure.
-    @ObservationIgnored private var consecutiveFailures: Int = 0
-
     // MARK: - Configuration
 
     /// How often to poll /health when connected (seconds).
-    /// The WebSocket is the real-time signal; this is just a sanity check.
-    private let connectedPollInterval: TimeInterval = 30
+    private let connectedPollInterval: TimeInterval = 15
 
     /// Base delay for exponential backoff when disconnected (seconds).
     private let disconnectedBaseDelay: TimeInterval = 2
@@ -111,20 +86,10 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     private let disconnectedMaxDelay: TimeInterval = 15
 
     /// How long to wait before showing the overlay (debounce, seconds).
-    /// 3 s covers brief network hiccups and background→foreground transitions
-    /// without flashing the overlay to the user.
-    private let overlayDebounce: TimeInterval = 3.0
-
-    /// Timeout for a single /health request (seconds).
-    /// Fast enough to detect real failures; long enough for slow networks.
-    private let healthCheckTimeout: TimeInterval = 8
+    private let overlayDebounce: TimeInterval = 1.5
 
     /// Timeout for the external ping (seconds).
     private let externalPingTimeout: TimeInterval = 5
-
-    /// Number of consecutive /health failures required before declaring
-    /// the server down. Eliminates false positives from a single slow request.
-    private let failureThreshold: Int = 2
 
     // MARK: - Lifecycle
 
@@ -137,11 +102,14 @@ final class ServerConnectionMonitor: @unchecked Sendable {
         self.apiClient = apiClient
         self.socketService = socketService
         isRunning = true
-        isAppInBackground = false
-        consecutiveFailures = 0
 
         startPathMonitor()
         startHealthPoll()
+
+        // Wire socket disconnect to trigger immediate health check
+        socketService?.onDisconnect = { [weak self] _ in
+            self?.triggerImmediateCheck()
+        }
 
         logger.info("Connection monitor started")
     }
@@ -155,10 +123,7 @@ final class ServerConnectionMonitor: @unchecked Sendable {
         healthPollTask = nil
         debounceTask?.cancel()
         debounceTask = nil
-        foregroundTask?.cancel()
-        foregroundTask = nil
         immediateCheckInFlight = false
-        consecutiveFailures = 0
 
         // Reset state
         connectionState = .connected
@@ -169,59 +134,9 @@ final class ServerConnectionMonitor: @unchecked Sendable {
         logger.info("Connection monitor stopped")
     }
 
-    // MARK: - App Lifecycle
-
-    /// Called when the app moves to the background (.inactive / .background).
-    ///
-    /// Suppresses transient HTTP failures to prevent false "server down"
-    /// overlays caused by the OS suspending network activity.
-    func markAppBackground() {
-        guard !isAppInBackground else { return }
-        isAppInBackground = true
-        // Cancel any pending foreground work
-        foregroundTask?.cancel()
-        foregroundTask = nil
-        // Reset the failure counter so background-era failures don't carry over
-        consecutiveFailures = 0
-        logger.debug("App backgrounded — suppressing transient HTTP failures")
-    }
-
-    /// Called when the app returns to the foreground (.active).
-    ///
-    /// Immediately triggers a health check and socket reconnect so the app
-    /// feels instantaneous on return, without waiting for the next poll cycle.
-    func markAppForeground() {
-        guard isAppInBackground else { return }
-        isAppInBackground = false
-        consecutiveFailures = 0
-        logger.debug("App foregrounded — triggering immediate health check + socket reconnect")
-
-        foregroundTask?.cancel()
-        foregroundTask = Task { [weak self] in
-            // Small delay to let the network stack settle after the OS
-            // resumes the app (avoids a spurious failure on the very first request)
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled else { return }
-
-            // Reconnect socket proactively (cancels any pending backoff timer)
-            await MainActor.run { [weak self] in
-                guard let self, let socket = self.socketService else { return }
-                if !socket.isConnected {
-                    socket.resetBackoffAndReconnect()
-                    self.logger.info("Foreground: triggered immediate socket reconnect")
-                }
-            }
-
-            // Then health check
-            await self?.checkServerHealth()
-        }
-    }
-
-    /// Triggers an immediate health check, e.g. on explicit user action.
+    /// Triggers an immediate health check, e.g. on foreground return.
     func triggerImmediateCheck() {
-        // Suppress while backgrounded — the OS may have suspended our network
-        // activity, so a failure here would be a false positive.
-        guard isRunning, !immediateCheckInFlight, !isAppInBackground else { return }
+        guard isRunning, !immediateCheckInFlight else { return }
         immediateCheckInFlight = true
 
         Task { [weak self] in
@@ -244,19 +159,14 @@ final class ServerConnectionMonitor: @unchecked Sendable {
             self.isNetworkAvailable = nowAvailable
 
             if !nowAvailable {
-                // Device lost internet — transition immediately even in background
-                // (NWPathMonitor is reliable; this is a real loss)
+                // Device lost internet — transition immediately
                 Task { @MainActor [weak self] in
-                    self?.consecutiveFailures = self?.failureThreshold ?? 2 // mark as failed
                     self?.transitionTo(.internetDown)
                 }
             } else if !wasAvailable && nowAvailable {
-                // Internet just came back
-                self.logger.info("NWPathMonitor: network restored")
-                // Only run an immediate check if we're in the foreground
-                if !self.isAppInBackground {
-                    self.triggerImmediateCheck()
-                }
+                // Internet just came back — immediate health check
+                self.logger.info("NWPathMonitor: network restored, triggering health check")
+                self.triggerImmediateCheck()
             }
         }
 
@@ -273,15 +183,12 @@ final class ServerConnectionMonitor: @unchecked Sendable {
             while !Task.isCancelled {
                 guard let self, self.isRunning else { break }
 
-                // Skip health polls while backgrounded — they'd fail spuriously
-                // and we have NWPathMonitor for background internet loss
-                if !self.isAppInBackground {
-                    await self.checkServerHealth()
-                }
+                await self.checkServerHealth()
 
                 guard !Task.isCancelled else { break }
 
-                let interval = await self.currentPollInterval()
+                // Sleep duration depends on current state
+                let interval = self.currentPollInterval()
                 try? await Task.sleep(for: .seconds(interval))
             }
         }
@@ -301,38 +208,22 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     private func checkServerHealth() async {
         guard let apiClient else { return }
 
-        let healthy = await apiClient.checkHealthFast(timeout: healthCheckTimeout)
+        let healthy = await apiClient.checkHealth()
 
         await MainActor.run { [weak self] in
             guard let self else { return }
 
             if healthy {
-                // Reset failure counter on any success
-                self.consecutiveFailures = 0
                 self.transitionTo(.connected)
+            } else if !self.isNetworkAvailable {
+                self.transitionTo(.internetDown)
             } else {
-                // Don't count background failures
-                if !self.isAppInBackground {
-                    self.consecutiveFailures += 1
-                    self.logger.debug("Health check failure \(self.consecutiveFailures)/\(self.failureThreshold)")
-                }
-
-                // Only declare a problem after threshold consecutive failures
-                guard self.consecutiveFailures >= self.failureThreshold else {
-                    self.logger.debug("Health check failed but below threshold — ignoring")
-                    return
-                }
-
-                if !self.isNetworkAvailable {
-                    self.transitionTo(.internetDown)
-                } else {
-                    // NWPath says we're online — check if internet actually works
-                    Task { [weak self] in
-                        guard let self else { return }
-                        let externalReachable = await self.pingExternalEndpoint()
-                        await MainActor.run {
-                            self.transitionTo(externalReachable ? .serverDown : .internetDown)
-                        }
+                // NWPath says we're online — check if internet actually works
+                Task { [weak self] in
+                    guard let self else { return }
+                    let externalReachable = await self.pingExternalEndpoint()
+                    await MainActor.run {
+                        self.transitionTo(externalReachable ? .serverDown : .internetDown)
                     }
                 }
             }
@@ -374,20 +265,11 @@ final class ServerConnectionMonitor: @unchecked Sendable {
                 onReconnected()
             }
             reconnectAttempt = 0
-            consecutiveFailures = 0
             disconnectedSince = nil
             connectionState = .connected
             updateOverlayVisibility(disconnected: false)
         } else {
             // Entering a disconnected state
-
-            // While backgrounded, only show internet-down states (NWPathMonitor-driven)
-            // Suppress server-down overlays from HTTP timeouts in the background
-            if isAppInBackground && newState == .serverDown {
-                logger.debug("Suppressing serverDown transition while app is backgrounded")
-                return
-            }
-
             if oldState == .connected {
                 disconnectedSince = Date()
                 logger.warning("Connection lost: \(String(describing: newState))")
@@ -405,9 +287,9 @@ final class ServerConnectionMonitor: @unchecked Sendable {
     /// Called when the server becomes reachable again.
     @MainActor
     private func onReconnected() {
-        // Reconnect socket if it's not already connected
+        // Reconnect socket if it's not connected
         if let socket = socketService, !socket.isConnected {
-            socket.resetBackoffAndReconnect()
+            socket.connect(force: true)
             logger.info("Triggered socket reconnection after server recovery")
         }
     }
@@ -423,13 +305,11 @@ final class ServerConnectionMonitor: @unchecked Sendable {
             // Hide overlay immediately on reconnection
             isShowingOverlay = false
         } else if !isShowingOverlay {
-            // Show overlay after debounce delay — prevents flickering on transient blips
+            // Show overlay after debounce delay
             debounceTask = Task { @MainActor [weak self] in
-                guard let self else { return }
-                try? await Task.sleep(for: .seconds(self.overlayDebounce))
+                try? await Task.sleep(for: .seconds(self?.overlayDebounce ?? 1.5))
                 guard !Task.isCancelled else { return }
-                // Double-check we're still disconnected and in the foreground
-                guard self.connectionState != .connected, !self.isAppInBackground else { return }
+                guard let self, self.connectionState != .connected else { return }
                 self.isShowingOverlay = true
             }
         }

--- a/Open UI/Core/Services/ServerSpeechRecognitionService.swift
+++ b/Open UI/Core/Services/ServerSpeechRecognitionService.swift
@@ -144,9 +144,9 @@ final class ServerSpeechRecognitionService {
         // Use .voiceChat (not .measurement) so echo cancellation stays active.
         // .allowBluetooth enables HFP input for CarPlay / BT headset microphones.
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .voiceChat,
-                                options: [.allowBluetoothHFP, .allowBluetoothA2DP])
-        try session.setActive(true, options: .notifyOthersOnDeactivation)
+      try session.setCategory(.playAndRecord, mode: .voiceChat,
+                                 options: [.allowBluetoothHFP, .allowBluetoothA2DP])
+        try session.setActive(true)
 
         // Create temp file
         let tempDir = FileManager.default.temporaryDirectory

--- a/Open UI/Core/Services/SpeechRecognitionService.swift
+++ b/Open UI/Core/Services/SpeechRecognitionService.swift
@@ -167,9 +167,9 @@ final class SpeechRecognitionService {
         // Include .allowBluetooth (HFP input) alongside .allowBluetoothA2DP (A2DP output)
         // so the car microphone is accessible when CarPlay is connected.
         let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .voiceChat,
-                                     options: [.allowBluetoothHFP, .allowBluetoothA2DP])
-        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+       try audioSession.setCategory(.playAndRecord, mode: .voiceChat,
+                                      options: [.allowBluetoothHFP, .allowBluetoothA2DP])
+        try audioSession.setActive(true)
 
         // Create recognition request
         let request = SFSpeechAudioBufferRecognitionRequest()

--- a/Open UI/Core/Services/StreamingContentStore.swift
+++ b/Open UI/Core/Services/StreamingContentStore.swift
@@ -240,7 +240,6 @@ final class StreamingContentStore {
         // Fire drain completion AFTER state is clean so the callback's
         // message.isStreaming = false and cleanupStreaming() see a fully
         // idle store and don't re-trigger double cleanup.
-        Haptics.streamingComplete()
         completion?()
     }
 }

--- a/Open UI/Core/Services/TextToSpeechService.swift
+++ b/Open UI/Core/Services/TextToSpeechService.swift
@@ -579,13 +579,13 @@ final class TextToSpeechService: NSObject {
         // Voice calls use .voiceChat mode for echo cancellation + HFP mic routing.
         // All other TTS (chat read-aloud) uses the global baseline (.playAndRecord .default)
         // so it ignores the silent switch and mixes with other app audio.
-        audioSessionManager?.configureSession { session in
+        audioSessionManager?.configureSession { [self] session in
             if speakerOverride {
                 try session.setCategory(.playAndRecord, mode: .voiceChat,
                                         options: [.allowBluetoothHFP, .allowBluetoothA2DP, .mixWithOthers])
                 try session.setActive(true)
                 // setActive resets overrideOutputAudioPort — re-apply the current routing preference.
-                try session.overrideOutputAudioPort(outputPortOverride)
+                try session.overrideOutputAudioPort(self.outputPortOverride)
             } else {
                 // Global baseline: .playAndRecord ignores silent switch; .defaultToSpeaker routes
                 // to loud speaker; .mixWithOthers doesn't interrupt other app audio.
@@ -768,14 +768,14 @@ final class TextToSpeechService: NSObject {
         utterance.preUtteranceDelay = 0
         utterance.postUtteranceDelay = 0.05
 
-        audioSessionManager?.configureSession { session in
+        audioSessionManager?.configureSession { [self] session in
             if speakerOverrideEnabled {
                 // Voice call — .voiceChat mode enables echo cancellation + HFP mic routing.
                 try session.setCategory(.playAndRecord, mode: .voiceChat,
                                         options: [.allowBluetoothHFP, .allowBluetoothA2DP, .mixWithOthers])
                 try session.setActive(true)
                 // setActive resets overrideOutputAudioPort — re-apply earpiece/speaker preference.
-                try session.overrideOutputAudioPort(outputPortOverride)
+                try session.overrideOutputAudioPort(self.outputPortOverride)
             } else {
                 // Regular read-aloud — use global baseline so silent switch is ignored.
                 try session.setCategory(.playAndRecord, mode: .default,

--- a/Open UI/Core/Services/TextToSpeechService.swift
+++ b/Open UI/Core/Services/TextToSpeechService.swift
@@ -83,6 +83,11 @@ final class TextToSpeechService: NSObject {
     /// Prevents re-enabling auto-lock while a voice call is already holding it.
     private var ttsHoldsIdleTimerLock: Bool = false
 
+    /// Reference to the shared audio session manager for coordinated session control.
+    /// Set by VoiceCallViewModel at call start so TTS can use the serial queue
+    /// and check shouldNotifyOthersOnDeactivation before deactivating.
+    weak var audioSessionManager: AudioSessionManager?
+
     func configureServerTTS(apiClient: APIClient?) {
         self.apiClient = apiClient
     }
@@ -570,24 +575,25 @@ final class TextToSpeechService: NSObject {
         let voiceId = serverVoiceId ?? serverDefaultVoice
         let speakerOverride = speakerOverrideEnabled
 
-        // Configure audio session before starting the player.
+       // Configure audio session before starting the player through the serial queue.
         // Voice calls use .voiceChat mode for echo cancellation + HFP mic routing.
         // All other TTS (chat read-aloud) uses the global baseline (.playAndRecord .default)
         // so it ignores the silent switch and mixes with other app audio.
-        let session = AVAudioSession.sharedInstance()
-        if speakerOverride {
-            try? session.setCategory(.playAndRecord, mode: .voiceChat,
-                                     options: [.allowBluetoothHFP, .allowBluetoothA2DP, .mixWithOthers])
-            try? session.setActive(true)
-            // setActive resets overrideOutputAudioPort — re-apply the current routing preference.
-            try? session.overrideOutputAudioPort(outputPortOverride)
-        } else {
-            // Global baseline: .playAndRecord ignores silent switch; .defaultToSpeaker routes
-            // to loud speaker; .mixWithOthers doesn't interrupt other app audio.
-            try? session.setCategory(.playAndRecord, mode: .default,
-                                     options: [.defaultToSpeaker, .allowBluetoothHFP,
-                                               .allowBluetoothA2DP, .mixWithOthers])
-            try? session.setActive(true)
+        audioSessionManager?.configureSession { session in
+            if speakerOverride {
+                try session.setCategory(.playAndRecord, mode: .voiceChat,
+                                        options: [.allowBluetoothHFP, .allowBluetoothA2DP, .mixWithOthers])
+                try session.setActive(true)
+                // setActive resets overrideOutputAudioPort — re-apply the current routing preference.
+                try session.overrideOutputAudioPort(outputPortOverride)
+            } else {
+                // Global baseline: .playAndRecord ignores silent switch; .defaultToSpeaker routes
+                // to loud speaker; .mixWithOthers doesn't interrupt other app audio.
+                try session.setCategory(.playAndRecord, mode: .default,
+                                        options: [.defaultToSpeaker, .allowBluetoothHFP,
+                                                  .allowBluetoothA2DP, .mixWithOthers])
+                try session.setActive(true)
+            }
         }
 
         // Create a fresh AVQueuePlayer for this playback session
@@ -762,8 +768,7 @@ final class TextToSpeechService: NSObject {
         utterance.preUtteranceDelay = 0
         utterance.postUtteranceDelay = 0.05
 
-        do {
-            let session = AVAudioSession.sharedInstance()
+        audioSessionManager?.configureSession { session in
             if speakerOverrideEnabled {
                 // Voice call — .voiceChat mode enables echo cancellation + HFP mic routing.
                 try session.setCategory(.playAndRecord, mode: .voiceChat,
@@ -778,8 +783,6 @@ final class TextToSpeechService: NSObject {
                                                   .allowBluetoothA2DP, .mixWithOthers])
                 try session.setActive(true)
             }
-        } catch {
-            // Audio session config failed — proceed anyway, system will use defaults
         }
 
         isSpeakingSystemChunk = true
@@ -807,11 +810,16 @@ final class TextToSpeechService: NSObject {
 
     /// Deactivates the shared audio session to release hardware resources.
     /// Called after all TTS playback finishes (both natural completion and stop()).
+    /// During voice calls, omits `.notifyOthersOnDeactivation` to prevent
+    /// Spotify/music from resuming between listen/speak cycles.
     private func deactivateAudioSession() {
-        try? AVAudioSession.sharedInstance().setActive(
-            false,
-            options: .notifyOthersOnDeactivation
-        )
+        let session = AVAudioSession.sharedInstance()
+        let shouldNotify = audioSessionManager?.shouldNotifyOthersOnDeactivation ?? true
+        if shouldNotify {
+            try? session.setActive(false, options: .notifyOthersOnDeactivation)
+        } else {
+            try? session.setActive(false)
+        }
     }
 
     // MARK: - Chunk Enqueuing (used by streaming TTS)

--- a/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
@@ -2435,46 +2435,22 @@ final class ChatViewModel {
         syncUIWithModelDefaults()
     }
 
-    /// `true` while `saveTemporaryChat()` is in-flight — used to show a loading state.
-    var isSavingTemporaryChat: Bool = false
-
-    /// Converts a temporary chat into a permanent one using a single
-    /// `POST /api/v1/chats/new` call with the full chat payload (history tree +
-    /// flat messages array), mirroring the web UI "save temp chat" flow exactly.
-    ///
-    /// After success:
-    /// - `conversation.id` is updated to the server-assigned ID in-place
-    /// - `isTemporaryChat` is set to `false`
-    /// - `conversationListNeedsRefresh` is posted so the sidebar picks up the new chat
-    ///
-    /// The view stays in place — no navigation happens — so there is zero visual glitch.
+    /// Converts a temporary chat into a permanent one by saving it to the server.
     func saveTemporaryChat() async {
         guard isTemporaryChat, let conversation, let manager else { return }
-        guard !isSavingTemporaryChat else { return }
-        isSavingTemporaryChat = true
-        defer { isSavingTemporaryChat = false }
-
         let modelId = selectedModelId ?? conversation.model ?? ""
-        // Strip the "local:" prefix to get a plain UUID for the server payload.
-        // The server will assign its own ID, but we pass ours as a hint.
-        let localId = conversation.id.hasPrefix("local:")
-            ? String(conversation.id.dropFirst("local:".count))
-            : conversation.id
-
         do {
-            let created = try await manager.apiClient.createConversationWithHistory(
-                id: localId,
-                title: conversation.title,
-                model: modelId.isEmpty ? nil : modelId,
-                history: conversation.history,
-                messages: conversation.messages,
-                chatParams: conversation.chatParams,
-                folderId: folderContextId
-            )
-            // Swap the local ID for the server-assigned one — in-place, no reload.
+            let created = try await manager.createConversation(
+                title: conversation.title, messages: [], model: modelId,
+                folderId: folderContextId)
+            // Update the conversation ID to the server-assigned one
             self.conversation?.id = created.id
+            // Sync all messages
+            try await manager.syncConversationMessages(
+                id: created.id, messages: conversation.messages, model: modelId,
+                chatParams: conversation.chatParams)
             isTemporaryChat = false
-            logger.info("Temporary chat saved as permanent: \(created.id)")
+            logger.info("Temporary chat saved as \(created.id)")
             NotificationCenter.default.post(name: .conversationListNeedsRefresh, object: nil)
         } catch {
             logger.error("Failed to save temporary chat: \(error.localizedDescription)")

--- a/Open UI/Features/Chat/Views/ChatDetailView.swift
+++ b/Open UI/Features/Chat/Views/ChatDetailView.swift
@@ -51,9 +51,6 @@ struct ChatDetailView: View {
     @State private var isUserDriving = false
     /// Rate-limit timestamp for the streaming scroll pump (writes are non-rendering).
     private let _pumpRef = PumpRef()
-    /// Whether streaming responses should automatically scroll the chat to the bottom.
-    /// Enabled by default (matches existing behaviour). Users can disable in Chat Behavior settings.
-    @AppStorage("streamingAutoScroll") private var streamingAutoScroll = true
 
     // MARK: Message pagination (sliding window — memory optimization)
     /// The ending index (exclusive) of the visible message window.
@@ -523,38 +520,6 @@ struct ChatDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(viewModel.isTemporaryChat ? "Temporary chat on" : "Temporary chat off")
-            }
-            if viewModel.isTemporaryChat && !viewModel.messages.isEmpty {
-                Button {
-                    Haptics.play(.medium)
-                    Task { await viewModel.saveTemporaryChat() }
-                } label: {
-                    ZStack {
-                        if viewModel.isSavingTemporaryChat {
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                                .scaleEffect(0.7)
-                                .tint(theme.brandPrimary)
-                        } else {
-                            ZStack {
-                                Circle()
-                                    .strokeBorder(
-                                        style: StrokeStyle(lineWidth: 1.5, dash: [3, 2])
-                                    )
-                                    .foregroundStyle(theme.brandPrimary)
-                                    .frame(width: 18, height: 18)
-                                Image(systemName: "checkmark")
-                                    .scaledFont(size: 9, weight: .bold)
-                                    .foregroundStyle(theme.brandPrimary)
-                            }
-                        }
-                    }
-                    .frame(width: 34, height: 34)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(viewModel.isSavingTemporaryChat)
-                .accessibilityLabel("Save as permanent chat")
             }
         }
     }
@@ -1040,14 +1005,7 @@ struct ChatDetailView: View {
 
             guard new > old else { return }
 
-            // ── Scroll to bottom when a new message is added ──
-            // When streamingAutoScroll is off, skip the scroll if the newly-added
-            // message is an assistant placeholder (i.e. streaming is about to start).
-            // User-sent messages always scroll so the user sees what they sent.
-            let lastMessage = viewModel.messages.last
-            let isAssistantAddition = lastMessage?.role == .assistant && old > 0
-            guard streamingAutoScroll || !isAssistantAddition else { return }
-
+            // ── ALWAYS scroll to bottom when a new message is added ──
             isScrolledUp = false
             isUserDriving = false
 
@@ -1074,11 +1032,10 @@ struct ChatDetailView: View {
                 }
             }
         }
-        // Streaming start: re-engage auto-scroll only when streamingAutoScroll is enabled.
-        // When disabled, the user stays at their current position and must manually
-        // scroll to the bottom to pick up the streaming pump.
+        // Streaming start: always re-engage auto-scroll. Only a user touch
+        // during the active stream (detected via onScrollPhaseChange) can break it.
         .onChange(of: viewModel.isStreaming) { _, streaming in
-            if streaming && streamingAutoScroll {
+            if streaming {
                 isScrolledUp = false
                 isUserDriving = false
                 scrollPosition.scrollTo(edge: .bottom)
@@ -1136,11 +1093,7 @@ struct ChatDetailView: View {
         // layout reflows, WKWebView resizes, and programmatic scrolls never
         // emit .interacting — they emit .animating or .idle.
         .onScrollPhaseChange { _, newPhase in
-            // Only count actual finger contact as user-driven. Excluding .decelerating
-            // prevents programmatic scrollTo() animations finishing their deceleration
-            // from falsely setting isUserDriving = true, which was racing with the
-            // offset observer to incorrectly flip isScrolledUp = true and kill auto-scroll.
-            isUserDriving = (newPhase == .interacting)
+            isUserDriving = (newPhase == .interacting || newPhase == .decelerating)
         }
         .onScrollGeometryChange(for: CGPoint.self) { geo in
             geo.contentOffset

--- a/Open UI/Features/Settings/Views/SettingsView.swift
+++ b/Open UI/Features/Settings/Views/SettingsView.swift
@@ -107,7 +107,7 @@ struct SettingsView: View {
                         SettingsCell(
                             icon: "bubble.left.and.bubble.right",
                             title: "Chat Behavior",
-                            subtitle: "Haptics, titles, suggestions, scrolling",
+                            subtitle: "Haptics, titles, suggestions",
                             showDivider: false,
                             accessory: .chevron
                         ) {
@@ -501,7 +501,6 @@ struct ChatSettingsView: View {
     @AppStorage("suggestionsEnabled") private var suggestionsEnabled = true
     @AppStorage("temporaryChatDefault") private var temporaryChatDefault = false
     @AppStorage("expandThinkingWhileStreaming") private var expandThinkingWhileStreaming = true
-    @AppStorage("streamingAutoScroll") private var streamingAutoScroll = true
     @AppStorage("citationShowDomain") private var citationShowDomain: Bool = true
     @AppStorage("quickPills") private var quickPillsData: String = ""
     @State private var availableTools: [ToolItem] = []
@@ -570,15 +569,6 @@ struct ChatSettingsView: View {
                 Text("Haptic feedback pulses as each token streams in.")
             }
 
-            // Section {
-            //     Toggle("Auto-scroll when response starts", isOn: $streamingAutoScroll)
-            //         .tint(theme.brandPrimary)
-            // } header: {
-            //     Text("Scroll Behavior")
-            // } footer: {
-            //     Text("When enabled, the chat automatically scrolls to the bottom as a response streams in. When disabled, your position is unchanged — scroll to the bottom manually to follow along.")
-            // }
-
             Section {
                 Toggle("Auto-generate chat titles", isOn: $titleGenerationEnabled)
                     .tint(theme.brandPrimary)
@@ -622,6 +612,44 @@ struct ChatSettingsView: View {
             } footer: {
                 Text("When enabled, citation badges show the website domain (e.g. bbc.com). When disabled, the page title is shown instead.")
             }
+
+            Section {
+                Text("Choose which quick actions appear below the message input. Tap to toggle.")
+                    .scaledFont(size: 12, weight: .medium)
+                    .foregroundStyle(theme.textTertiary)
+                    .listRowSeparator(.hidden)
+
+                // Built-in pills
+                quickPillToggle(id: "web", icon: "magnifyingglass", name: "Web Search")
+                quickPillToggle(id: "image", icon: "photo", name: "Image Generation")
+
+                // Server tools
+                if isLoadingTools {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text("Loading tools…")
+                            .scaledFont(size: 12, weight: .medium)
+                            .foregroundStyle(theme.textTertiary)
+                    }
+                } else {
+                    ForEach(availableTools, id: \.id) { tool in
+                        quickPillToggle(id: tool.id, icon: "wrench", name: tool.name)
+                    }
+                }
+
+                if !selectedPillIds.isEmpty {
+                    Button(role: .destructive) {
+                        quickPillsData = ""
+                        Haptics.play(.medium)
+                    } label: {
+                        Label("Clear All Quick Actions", systemImage: "xmark.circle")
+                    }
+                }
+            } header: {
+                Text("Quick Actions")
+            } footer: {
+                Text("\(selectedPillIds.count) action\(selectedPillIds.count == 1 ? "" : "s") selected")
+            }
         }
         .navigationTitle("Chat Settings")
         .navigationBarTitleDisplayMode(.inline)
@@ -631,19 +659,42 @@ struct ChatSettingsView: View {
         }
     }
 
+    private func quickPillToggle(id: String, icon: String, name: String) -> some View {
+        let isSelected = selectedPillIds.contains(id)
+        return Button {
+            withAnimation(.easeOut(duration: 0.15)) {
+                togglePill(id)
+            }
+        } label: {
+            HStack(spacing: Spacing.md) {
+                Image(systemName: icon)
+                    .scaledFont(size: 14, weight: .medium)
+                    .foregroundStyle(isSelected ? theme.brandPrimary : theme.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        (isSelected ? theme.brandPrimary : theme.textSecondary).opacity(0.12)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                Text(name)
+                    .scaledFont(size: 16)
+                    .foregroundStyle(theme.textPrimary)
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .scaledFont(size: 20)
+                    .foregroundStyle(isSelected ? theme.brandPrimary : theme.textTertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
     private func loadTools() async {
-        guard let client = dependencies.apiClient else { return }
+        guard let manager = dependencies.conversationManager else { return }
         isLoadingTools = true
         do {
-            let rawTools = try await client.getTools()
-            availableTools = rawTools.compactMap { raw -> ToolItem? in
-                guard let id = raw["id"] as? String else { return nil }
-                let name = raw["name"] as? String ?? id
-                let description = (raw["meta"] as? [String: Any])?["description"] as? String ?? ""
-                let isActive = raw["is_active"] as? Bool ?? true
-                let hasUserValves = raw["has_user_valves"] as? Bool ?? false
-                return ToolItem(id: id, name: name, description: description, isEnabled: isActive, hasUserValves: hasUserValves)
-            }
+            availableTools = try await manager.fetchTools()
         } catch {}
         isLoadingTools = false
     }

--- a/Open UI/Features/VoiceCall/ViewModels/VoiceCallViewModel.swift
+++ b/Open UI/Features/VoiceCall/ViewModels/VoiceCallViewModel.swift
@@ -77,17 +77,22 @@ final class VoiceCallViewModel {
     /// Cancelled in `endCall()` so TTS stops immediately when the user disconnects.
     private var responseTask: Task<Void, Never>?
 
+    /// Centralized audio session manager for interruption/route-change handling.
+    private let audioSessionManager: AudioSessionManager
+
     // MARK: - Init (Apple on-device STT)
 
     init(
         speechService: SpeechRecognitionService,
         ttsService: TextToSpeechService,
-        callKitManager: CallKitManager
+        callKitManager: CallKitManager,
+        audioSessionManager: AudioSessionManager
     ) {
         self.speechService = speechService
         self.serverSpeechService = nil
         self.ttsService = ttsService
         self.callKitManager = callKitManager
+        self.audioSessionManager = audioSessionManager
 
         setupCallbacks()
     }
@@ -97,12 +102,14 @@ final class VoiceCallViewModel {
     init(
         serverSpeechService: ServerSpeechRecognitionService,
         ttsService: TextToSpeechService,
-        callKitManager: CallKitManager
+        callKitManager: CallKitManager,
+        audioSessionManager: AudioSessionManager
     ) {
         self.speechService = nil
         self.serverSpeechService = serverSpeechService
         self.ttsService = ttsService
         self.callKitManager = callKitManager
+        self.audioSessionManager = audioSessionManager
 
         setupCallbacks()
     }
@@ -150,6 +157,12 @@ final class VoiceCallViewModel {
         // stop working if the device sleeps. Restored in endCall().
         UIApplication.shared.isIdleTimerDisabled = true
 
+        // Signal the audio session manager that a voice call is active.
+        // This prevents .notifyOthersOnDeactivation during TTS between cycles,
+        // which would cause Spotify/music to resume on CarPlay.
+        audioSessionManager.voiceCallStarted()
+        ttsService.audioSessionManager = audioSessionManager
+
         // Start CallKit session
         do {
             try await callKitManager.startCall(displayName: modelName.isEmpty ? "AI Assistant" : modelName)
@@ -189,6 +202,9 @@ final class VoiceCallViewModel {
     /// Ends the current voice call.
     func endCall() async {
         stopActiveSTT()
+        // Signal the audio session manager that the voice call is ending
+        // so it can restore normal deactivation behavior.
+        audioSessionManager.voiceCallEnded()
         // Cancel the response pipeline first so waitForResponseAndSpeak() stops looping
         // and cannot call finishStreamingTTS() or startListening() after we end the call.
         responseTask?.cancel()
@@ -211,11 +227,12 @@ final class VoiceCallViewModel {
 
         // Restore the global baseline audio session so HTML audio and regular TTS
         // continue working after the voice call ends.
-        let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.playAndRecord, mode: .default,
-                                 options: [.defaultToSpeaker, .allowBluetoothHFP,
-                                           .allowBluetoothA2DP, .mixWithOthers])
-        try? session.setActive(true)
+        audioSessionManager.configureSession { session in
+            try session.setCategory(.playAndRecord, mode: .default,
+                                    options: [.defaultToSpeaker, .allowBluetoothHFP,
+                                              .allowBluetoothA2DP, .mixWithOthers])
+            try session.setActive(true)
+        }
 
         // Reset voice mode flag so normal chat from the same ChatViewModel
         // doesn't continue sending features.voice=true after the call ends.
@@ -486,18 +503,15 @@ final class VoiceCallViewModel {
         // .allowBluetooth enables HFP input (car mic / BT headset mic).
         // .allowBluetoothA2DP enables A2DP output.
         // Without .allowBluetooth the CarPlay / BT mic is not routed and STT hears silence.
-        do {
-            let session = AVAudioSession.sharedInstance()
-            // Do NOT use .defaultToSpeaker here — it overrides overrideOutputAudioPort(.none)
-            // on every cycle and prevents the speaker button from turning off.
-            // Speaker routing is controlled exclusively via applySpeakerOverride().
+        // Do NOT use .defaultToSpeaker here — it overrides overrideOutputAudioPort(.none)
+        // on every cycle and prevents the speaker button from turning off.
+        // Speaker routing is controlled exclusively via applySpeakerOverride().
+        audioSessionManager.configureSession { session in
             try session.setCategory(.playAndRecord, mode: .voiceChat,
                                     options: [.allowBluetoothHFP, .allowBluetoothA2DP])
             try session.setActive(true)
-            applySpeakerOverride()
-        } catch {
-            logger.warning("Audio session reconfig for listening: \(error.localizedDescription)")
         }
+        applySpeakerOverride()
 
         currentTranscript = ""
         callState = .listening
@@ -595,20 +609,12 @@ final class VoiceCallViewModel {
 
         // Pre-configure the audio session before TTS starts.
         // Keep .allowBluetooth so CarPlay / BT HFP stays routed for the full cycle.
-        for attempt in 1...3 {
-            do {
-                let session = AVAudioSession.sharedInstance()
-                // Do NOT use .defaultToSpeaker — see startListening() comment.
-                try session.setCategory(.playAndRecord, mode: .voiceChat,
-                                        options: [.allowBluetoothHFP, .allowBluetoothA2DP])
-                try session.setActive(true)
-                applySpeakerOverride()
-                break
-            } catch {
-                logger.warning("Audio session attempt \(attempt)/3: \(error.localizedDescription)")
-                try? await Task.sleep(for: .milliseconds(200))
-            }
+        audioSessionManager.configureSession { session in
+            try session.setCategory(.playAndRecord, mode: .voiceChat,
+                                    options: [.allowBluetoothHFP, .allowBluetoothA2DP])
+            try session.setActive(true)
         }
+        applySpeakerOverride()
 
         chatViewModel.inputText = transcript
 

--- a/Open UI/Info.plist
+++ b/Open UI/Info.plist
@@ -34,8 +34,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Open Relay needs access to save images from chat to your Photos library.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Open Relay uses your location to provide location-aware responses when you enable the Share Location feature in Privacy &amp; Security settings.</string>
 	<key>NSAppTransportSecurity</key>

--- a/Open UI/Shared/Components/StreamingMarkdownView.swift
+++ b/Open UI/Shared/Components/StreamingMarkdownView.swift
@@ -639,17 +639,6 @@ struct StreamingMarkdownView: View {
         let linkURL: URL?
     }
 
-    /// Returns true for image URLs that can be rendered inline:
-    /// - `http` / `https` remote URLs
-    /// - `data:image/` Base64 data URIs
-    private static func isRenderableImageURL(_ url: URL) -> Bool {
-        switch url.scheme {
-        case "http", "https": return true
-        case "data":          return url.absoluteString.hasPrefix("data:image/")
-        default:              return false
-        }
-    }
-
     /// Scans `text` for markdown image syntax and returns all occurrences with their ranges.
     private func findMarkdownImages(in text: String) -> [ParsedImage] {
         let nsString = text as NSString
@@ -666,7 +655,7 @@ struct StreamingMarkdownView: View {
                       let imgRange = Range(match.range(at: 2), in: text),
                       let linkRange = Range(match.range(at: 3), in: text),
                       let imgURL = URL(string: String(text[imgRange])),
-                      Self.isRenderableImageURL(imgURL)
+                      imgURL.scheme == "http" || imgURL.scheme == "https"
                 else { continue }
 
                 let linkURLStr = String(text[linkRange])
@@ -690,7 +679,7 @@ struct StreamingMarkdownView: View {
                       let altRange = Range(match.range(at: 1), in: text),
                       let imgRange = Range(match.range(at: 2), in: text),
                       let imgURL = URL(string: String(text[imgRange])),
-                      Self.isRenderableImageURL(imgURL)
+                      imgURL.scheme == "http" || imgURL.scheme == "https"
                 else { continue }
 
                 // Skip if this overlaps with any linked image already found
@@ -964,15 +953,6 @@ struct StreamingMarkdownView: View {
 
 /// Renders a markdown image as a native SwiftUI async image with caching.
 /// Supports optional link wrapping — tapping opens the link URL in Safari.
-///
-/// ## Interactions
-/// - **Tap** → fullscreen viewer with pinch-to-zoom
-/// - **Long-press** → context menu with Save to Photos and Share options
-///
-/// ## Data URI support
-/// When the image URL is a `data:image/...;base64,...` URI, the Base64 payload
-/// is decoded directly into a `UIImage` — no network call is made.
-/// Remote `http`/`https` images go through `CachedAsyncImage` as before.
 private struct MarkdownInlineImageView: View {
     let imageURL: URL
     let altText: String
@@ -981,75 +961,7 @@ private struct MarkdownInlineImageView: View {
     @Environment(\.theme) private var theme
     @Environment(\.openURL) private var openURL
 
-    // Fullscreen sheet state (shared by both Base64 and remote paths).
-    @State private var showFullscreen = false
-    // For remote images: cache the downloaded UIImage so we can save/share it.
-    @State private var loadedRemoteImage: UIImage? = nil
-    // Feedback toast for save-to-photos action.
-    @State private var savedToPhotos = false
-
-    /// Attempts to decode a `data:image/...;base64,<payload>` URI into a UIImage.
-    /// Returns `nil` for any other scheme or malformed URI.
-    private static func decodeDataURI(_ url: URL) -> UIImage? {
-        let raw = url.absoluteString
-        guard raw.hasPrefix("data:image/") else { return nil }
-        // Find the comma that separates the header from the payload.
-        guard let commaIdx = raw.firstIndex(of: ",") else { return nil }
-        let header = raw[raw.startIndex..<commaIdx]
-        guard header.hasSuffix(";base64") else { return nil }
-        let base64 = String(raw[raw.index(after: commaIdx)...])
-        // Base64 strings from some models contain whitespace/newlines — strip them.
-        let cleaned = base64.components(separatedBy: .whitespacesAndNewlines).joined()
-        guard let data = Data(base64Encoded: cleaned, options: .ignoreUnknownCharacters) else { return nil }
-        return UIImage(data: data)
-    }
-
     var body: some View {
-        if imageURL.scheme == "data" {
-            // ── Inline Base64 data URI ────────────────────────────────────────
-            if let uiImage = Self.decodeDataURI(imageURL) {
-                base64ImageView(uiImage: uiImage)
-            } else {
-                dataURIErrorPlaceholder
-            }
-        } else {
-            // ── Remote http/https image ───────────────────────────────────────
-            remoteImageView
-        }
-    }
-
-    /// Displays a decoded UIImage (from a data URI) with fullscreen + context menu.
-    @ViewBuilder
-    private func base64ImageView(uiImage: UIImage) -> some View {
-        Image(uiImage: uiImage)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(maxWidth: .infinity, maxHeight: 300, alignment: .leading)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .contentShape(Rectangle())
-            .onTapGesture { showFullscreen = true }
-            .contextMenu { imageContextMenu(for: uiImage) }
-            .accessibilityLabel(altText.isEmpty ? "Image" : altText)
-            .accessibilityAddTraits(.isImage)
-            .sheet(isPresented: $showFullscreen) {
-                FullscreenImageViewer(image: uiImage, altText: altText)
-            }
-    }
-
-    /// Small placeholder shown when a data URI fails to decode.
-    private var dataURIErrorPlaceholder: some View {
-        RoundedRectangle(cornerRadius: 10)
-            .fill(theme.surfaceContainer.opacity(0.5))
-            .frame(height: 80)
-            .overlay {
-                Label("Image could not be decoded", systemImage: "photo")
-                    .scaledFont(size: 12)
-                    .foregroundStyle(theme.textTertiary)
-            }
-    }
-
-    /// Remote-image view via CachedAsyncImage (http / https).
-    private var remoteImageView: some View {
         CachedAsyncImage(url: imageURL) { image in
             image
                 .resizable()
@@ -1073,238 +985,18 @@ private struct MarkdownInlineImageView: View {
                 }
         }
         .contentShape(Rectangle())
-        .onTapGesture { showFullscreen = true }
-        .contextMenu {
-            if let img = loadedRemoteImage {
-                imageContextMenu(for: img)
+        .onTapGesture {
+            // If the image is wrapped in a link, open the link URL.
+            // Otherwise, open the image URL directly.
+            if let linkURL {
+                openURL(linkURL)
+            } else {
+                openURL(imageURL)
             }
         }
         .accessibilityLabel(altText.isEmpty ? "Image" : altText)
         .accessibilityAddTraits(.isImage)
-        .sheet(isPresented: $showFullscreen) {
-            // Use cached UIImage if available, otherwise fall back to URL-based viewer.
-            if let img = loadedRemoteImage {
-                FullscreenImageViewer(image: img, altText: altText)
-            } else {
-                FullscreenImageViewer(imageURL: imageURL, altText: altText)
-            }
-        }
-        .task(id: imageURL) {
-            // Download a UIImage copy in the background so save/share work without
-            // needing to render the SwiftUI Image back to a bitmap.
-            guard loadedRemoteImage == nil else { return }
-            guard let (data, _) = try? await URLSession.shared.data(from: imageURL) else { return }
-            if let img = UIImage(data: data) {
-                await MainActor.run { loadedRemoteImage = img }
-            }
-        }
-    }
-
-    /// Context menu items shared by both image types.
-    @ViewBuilder
-    private func imageContextMenu(for image: UIImage) -> some View {
-        Button {
-            UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-        } label: {
-            Label("Save to Photos", systemImage: "square.and.arrow.down")
-        }
-
-        Button {
-            shareImage(image)
-        } label: {
-            Label("Share", systemImage: "square.and.arrow.up")
-        }
-
-        if let linkURL {
-            Button {
-                openURL(linkURL)
-            } label: {
-                Label("Open Link", systemImage: "link")
-            }
-        }
-    }
-
-    /// Presents a `UIActivityViewController` for sharing the given image.
-    private func shareImage(_ image: UIImage) {
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else { return }
-        let vc = UIActivityViewController(activityItems: [image], applicationActivities: nil)
-        // iPad needs a source view for the popover.
-        vc.popoverPresentationController?.sourceView = rootVC.view
-        vc.popoverPresentationController?.sourceRect = CGRect(
-            x: rootVC.view.bounds.midX, y: rootVC.view.bounds.midY, width: 0, height: 0)
-        vc.popoverPresentationController?.permittedArrowDirections = []
-        rootVC.present(vc, animated: true)
-    }
-}
-
-// MARK: - Fullscreen Image Viewer
-
-/// Full-screen image viewer with pinch-to-zoom, Save, and Share toolbar actions.
-/// Accepts either a pre-decoded `UIImage` (Base64 path) or a remote `URL` (http/https path
-/// where the async download is still in progress).
-private struct FullscreenImageViewer: View {
-
-    // Exactly one of these will be non-nil.
-    var image: UIImage?
-    var imageURL: URL?
-    var altText: String
-
-    @Environment(\.dismiss) private var dismiss
-    @State private var scale: CGFloat = 1.0
-    @State private var lastScale: CGFloat = 1.0
-    @State private var offset: CGSize = .zero
-    @State private var lastOffset: CGSize = .zero
-    @State private var savedConfirmation = false
-
-    init(image: UIImage, altText: String) {
-        self.image = image
-        self.imageURL = nil
-        self.altText = altText
-    }
-
-    init(imageURL: URL, altText: String) {
-        self.image = nil
-        self.imageURL = imageURL
-        self.altText = altText
-    }
-
-    var body: some View {
-        NavigationStack {
-            GeometryReader { geo in
-                ZStack {
-                    Color.black.ignoresSafeArea()
-
-                    if let uiImage = image {
-                        zoomableImage(Image(uiImage: uiImage), size: geo.size)
-                    } else if let url = imageURL {
-                        CachedAsyncImage(url: url) { img in
-                            zoomableImage(img, size: geo.size)
-                        } placeholder: {
-                            ProgressView().tint(.white)
-                        }
-                    }
-
-                    // "Saved!" confirmation toast.
-                    if savedConfirmation {
-                        VStack {
-                            Spacer()
-                            Label("Saved to Photos", systemImage: "checkmark.circle.fill")
-                                .foregroundStyle(.white)
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 10)
-                                .background(.ultraThinMaterial, in: Capsule())
-                                .padding(.bottom, 32)
-                        }
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                    }
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Done") { dismiss() }
-                        .foregroundStyle(.white)
-                        .fontWeight(.semibold)
-                }
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    if let uiImage = image {
-                        Button {
-                            saveToPhotos(uiImage)
-                        } label: {
-                            Image(systemName: "square.and.arrow.down")
-                        }
-                        .foregroundStyle(.white)
-
-                        Button {
-                            shareImage(uiImage)
-                        } label: {
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                        .foregroundStyle(.white)
-                    }
-                }
-            }
-            .toolbarBackground(.black.opacity(0.6), for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-        }
-        .preferredColorScheme(.dark)
-    }
-
-    @ViewBuilder
-    private func zoomableImage(_ img: Image, size: CGSize) -> some View {
-        img
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: size.width, height: size.height)
-            .scaleEffect(scale)
-            .offset(offset)
-            .gesture(
-                MagnificationGesture()
-                    .onChanged { value in
-                        scale = max(1.0, min(lastScale * value, 6.0))
-                    }
-                    .onEnded { _ in
-                        lastScale = scale
-                        // Snap back if zoomed out below 1×.
-                        if scale < 1.0 {
-                            withAnimation(.spring()) {
-                                scale = 1.0
-                                offset = .zero
-                            }
-                            lastScale = 1.0
-                            lastOffset = .zero
-                        }
-                    }
-                    .simultaneously(with:
-                        DragGesture()
-                            .onChanged { value in
-                                // Only allow panning when zoomed in.
-                                guard scale > 1.0 else { return }
-                                offset = CGSize(
-                                    width: lastOffset.width + value.translation.width,
-                                    height: lastOffset.height + value.translation.height
-                                )
-                            }
-                            .onEnded { _ in
-                                lastOffset = offset
-                            }
-                    )
-            )
-            .onTapGesture(count: 2) {
-                withAnimation(.spring()) {
-                    if scale > 1.0 {
-                        scale = 1.0
-                        offset = .zero
-                        lastScale = 1.0
-                        lastOffset = .zero
-                    } else {
-                        scale = 2.5
-                        lastScale = 2.5
-                    }
-                }
-            }
-    }
-
-    private func saveToPhotos(_ uiImage: UIImage) {
-        UIImageWriteToSavedPhotosAlbum(uiImage, nil, nil, nil)
-        withAnimation(.spring()) { savedConfirmation = true }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            withAnimation { savedConfirmation = false }
-        }
-    }
-
-    private func shareImage(_ uiImage: UIImage) {
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else { return }
-        let vc = UIActivityViewController(activityItems: [uiImage], applicationActivities: nil)
-        vc.popoverPresentationController?.sourceView = rootVC.view
-        vc.popoverPresentationController?.sourceRect = CGRect(
-            x: rootVC.view.bounds.midX, y: rootVC.view.bounds.midY, width: 0, height: 0)
-        vc.popoverPresentationController?.permittedArrowDirections = []
-        rootVC.present(vc, animated: true)
+        .accessibilityAddTraits(.isLink)
     }
 }
 

--- a/Open UI/Shared/Components/StreamingWebPreview.swift
+++ b/Open UI/Shared/Components/StreamingWebPreview.swift
@@ -136,9 +136,9 @@ struct StreamingWebPreview: UIViewRepresentable {
                     coord.pendingReconcileWorkItem?.cancel()
                     coord.pendingReconcileWorkItem = nil
                     let capturedContent = content
-                    Task.detached(priority: .userInitiated) { [weak webView] in
+                    DispatchQueue.global(qos: .userInitiated).async {
                         let escaped = Coordinator.escape(capturedContent)
-                        await MainActor.run {
+                        DispatchQueue.main.async { [weak webView] in
                             webView?.evaluateJavaScript("reconcileContent(`\(escaped)`)", completionHandler: nil)
                         }
                     }
@@ -287,7 +287,7 @@ struct StreamingWebPreview: UIViewRepresentable {
         }
 
         /// Static wrapper so `webView(_:didFinish:)` can call it without capturing `self`.
-        static func escape(_ text: String) -> String {
+        nonisolated static func escape(_ text: String) -> String {
             text
                 .replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "`", with: "\\`")


### PR DESCRIPTION
## Summary

Fixes CarPlay volume-change pausing voice call/read aloud and resuming background media (Spotify, Apple Music, etc.). Adds centralized `AudioSessionManager` that handles audio interruptions, route changes, and CarPlay volume interception, wired through the dependency container.

## Type of Change

- [x]  Bug fix
- [x]  Refactor / code quality

## What Changed

- **New: `Open UI/Core/Services/AudioSessionManager.swift`** — Centralized AVAudioSession manager with:
  - `AVAudioSessionInterruptionNotification` listener that reactivates session on interruption end
  - `AVAudioSessionRouteChangeNotification` listener for `.volumeChanged`, `.newDeviceAvailable`, `.oldDeviceUnavailable`, `.categoryChange`
  - `MPRemoteCommandCenter.changePlaybackVolumeCommand` interception to consume CarPlay volume events without triggering interruption
  - Serial `AudioSessionQueue` actor to prevent concurrent `setCategory`/`setActive` races across TTS/STT/VoiceCall
  - `voiceCallStarted()`/`voiceCallEnded()` lifecycle + `shouldNotifyOthersOnDeactivation` property to prevent background media resume between listen/speak cycles

- **Edit: `Open UI/Core/Services/DependencyContainer.swift`** — Added `audioSessionManager` property, calls `startListening()` at launch, and injects it into `VoiceCallViewModel` via `makeVoiceCallViewModel()`

- **Edit: `Open UI/Core/Services/TextToSpeechService.swift`** — Uses `audioSessionManager?.configureSession()` instead of direct session config; conditional `.notifyOthersOnDeactivation` on stop based on voice call state

- **Edit: `Open UI/Features/VoiceCall/ViewModels/VoiceCallViewModel.swift`** — Injects `audioSessionManager`, calls `voiceCallStarted()`/`voiceCallEnded()`, uses `configureSession()` for all session config, restores baseline session in `endCall()`

- **Edit: `Open UI/Core/Services/CallKitManager.swift`** — Already imports `MediaPlayer`

- **Edit: `Open UI/Core/Services/SpeechRecognitionService.swift`** — No `.notifyOthersOnDeactivation` on `setActive(true)` 
- **Edit: `Open UI/Core/Services/ServerSpeechRecognitionService.swift`** — No `.notifyOthersOnDeactivation` on `setActive(true)`

## Screenshots / Recording

<!-- N/A — audio-only fix, no UI changes -->

## Testing

- [ ] Tested on device (iPhone)
- [ ] Tested on device (iPad) — if relevant
- [ ] Tested on iOS Simulator
- [x] Build succeeds with no warnings added
- [ ] No regressions in related features

**Manual test cases:**
- Voice call on CarPlay: turn volume knob up/down during listen and speak phases → call should not pause, Spotify should not resume
- Read aloud on CarPlay: turn volume knob → speech should continue uninterrupted
- Bluetooth headset connect/disconnect during voice call → audio should route correctly
- Normal phone call interruption during voice call → should handle gracefully

## Related Issues
[Closes #](https://github.com/Ichigo3766/Open-Relay/issues/62)