### PR TITLE
Fix premature stream finalization during silent reasoning/web-search phases (#157, #160)

### DIFF
--- a/Open UI/Core/Models/MessageHistory.swift
+++ b/Open UI/Core/Models/MessageHistory.swift
@@ -529,7 +529,13 @@ struct MessageHistory: Sendable {
                 }()
 
                 // Build the details block matching ToolCallParser expectations
-                // Result goes both as `result` attribute (fast path) and as body (fallback)
+                // Result goes both as `result` attribute (fast path) and as body (fallback).
+                // The body is entity-encoded like the attribute: tool results are arbitrary
+                // web content (search snippets, page HTML) and a raw body can contain
+                // unbalanced `<details`/`</details>` sequences that corrupt the depth-aware
+                // block scanners (StreamingPipeline / ToolCallParser mis-track block
+                // boundaries and leak or swallow content — #160). Both parser paths in
+                // ToolCallParser decode entities, so rendering is unchanged.
                 let block: String
                 if resultText.isEmpty {
                     block = """
@@ -541,7 +547,7 @@ struct MessageHistory: Sendable {
                     block = """
                     <details type="tool_calls" id="\(itemId)" name="\(name)" done="\(doneAttr)" arguments="\(encodedArgs)" result="\(encodedResult)"\(embedsAttr)>
                     <summary>Tool Executed</summary>
-                    \(resultText)
+                    \(htmlEntityEncode(resultText))
                     </details>
                     """
                 }
@@ -556,10 +562,14 @@ struct MessageHistory: Sendable {
                         return text
                     }.joined()
                     if !reasoningText.isEmpty {
+                        // Entity-encode the body (see tool_calls branch above): model
+                        // reasoning can itself contain `<details` markup that would
+                        // otherwise corrupt the block scanners and the think-tag
+                        // preprocessor. parseReasoningBlock decodes entities on read.
                         let block = """
                         <details type="reasoning" done="true">
                         <summary>Thinking</summary>
-                        \(reasoningText)
+                        \(htmlEntityEncode(reasoningText))
                         </details>
                         """
                         parts.append(block)

--- a/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
@@ -339,6 +339,18 @@ final class ChatViewModel {
     /// Tracks whether the socket has received at least one content token.
     /// Used by the recovery timer to avoid overwriting an active stream.
     private var socketHasReceivedContent = false
+    /// Wall-clock time of the last socket-delivered content token.
+    /// Lets the recovery timer distinguish an actively-streaming socket from one
+    /// that delivered earlier tokens and then went silent mid-response (e.g. right
+    /// after a tool call finished) — in the silent case the recovery poll may
+    /// adopt newer server content so the rest of the response still renders.
+    private var lastSocketContentAt: Date = .distantPast
+    /// True when the recovery poll adopted server content that the socket
+    /// accumulator (`acc`) never saw. If a `done:true` socket event arrives after
+    /// that, `acc.content` is STALE — finalizing with it would truncate the
+    /// message back to the pre-silence prefix. finishStreamingSuccessfully()
+    /// checks this flag and re-fetches the full content from the server instead.
+    private var recoveryAdoptedServerContent = false
     private(set) var serverBaseURL: String = ""
     @ObservationIgnored nonisolated(unsafe) private var foregroundObserver: NSObjectProtocol?
     @ObservationIgnored nonisolated(unsafe) private var backgroundObserver: NSObjectProtocol?
@@ -3140,6 +3152,8 @@ final class ChatViewModel {
         isStreaming = true
         hasFinishedStreaming = false
         socketHasReceivedContent = false
+        lastSocketContentAt = .distantPast
+        recoveryAdoptedServerContent = false
         selfInitiatedStream = true
         streamingSessionId += 1
         // Clear the replay-block for the previous completed message — a new
@@ -3311,56 +3325,132 @@ final class ChatViewModel {
                         self.activeTaskId = taskId
                     }
 
-                    // Aggressive polling: start immediately, poll every 1.5s
-                    // Content is being generated server-side and persisted to DB
-                    // in real-time. Each poll picks up the latest accumulated text.
-                    self.logger.info("HTTP POST done – starting aggressive polling (no socket)")
+                    // ── Task-aware polling ──
+                    // Content stability is NOT a completion signal: reasoning
+                    // models, web-search workflows, and long prompt-processing
+                    // phases can go minutes without emitting visible tokens
+                    // (issue #157). The server's task registry
+                    // (GET /api/tasks/chat/{chatId}) is authoritative:
+                    //   • task still registered → keep polling, stay "streaming"
+                    //   • task gone            → one final fetch, then finalize
+                    self.logger.info("HTTP POST done – starting task-aware polling (no socket)")
                     guard let chatId = effectiveChatId else {
                         self.cleanupStreaming()
                         return
                     }
                     var lastContentLength = 0
                     var staleCount = 0
-                    for _ in 0..<40 { // up to ~60s of polling
-                        if Task.isCancelled { break }
+                    var taskCheckFailures = 0
+                    var doneFlagPollCount = 0
+                    let pollingStartedAt = Date()
+
+                    // Shared finalize path for every completion route below.
+                    func finalizePolling(_ finalConversation: Conversation?) async {
+                        var finalContent = ""
+                        if let refreshed = finalConversation,
+                           let serverAssistant = refreshed.messages.last(where: { $0.role == .assistant }),
+                           !serverAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            finalContent = serverAssistant.content
+                            self.updateAssistantMessage(id: assistantMessageId, content: finalContent, isStreaming: false)
+                            self.adoptServerMessages(serverConversation: refreshed)
+                        } else {
+                            finalContent = self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? ""
+                            self.updateAssistantMessage(id: assistantMessageId, content: finalContent, isStreaming: false)
+                        }
+                        await manager.sendChatCompleted(chatId: chatId, messageId: assistantMessageId, model: modelId, sessionId: socketSessionId, messages: self.buildSimpleAPIMessages())
+                        try? await self.refreshConversationMetadata(chatId: chatId, assistantMessageId: assistantMessageId)
+                        self.cleanupStreaming()
+                        await self.sendCompletionNotificationIfNeeded(content: finalContent)
+                        NotificationCenter.default.post(name: .conversationListNeedsRefresh, object: nil)
+                    }
+
+                    while !Task.isCancelled {
                         try? await Task.sleep(nanoseconds: 1_500_000_000)
                         if Task.isCancelled { break }
 
+                        // Hard backstop — never poll forever, even if the task
+                        // registry keeps reporting an active (stuck) task.
+                        if Date().timeIntervalSince(pollingStartedAt) > 600 {
+                            self.logger.warning("Polling: hard timeout after 600s — finalizing with best available content")
+                            let best = try? await manager.fetchConversation(id: chatId)
+                            await finalizePolling(best)
+                            return
+                        }
+
+                        var latestConversation: Conversation? = nil
+                        var serverDone = false
+                        var sawContent = false
+
                         do {
                             let refreshed = try await manager.fetchConversation(id: chatId)
+                            latestConversation = refreshed
                             if let serverAssistant = refreshed.messages.last(where: { $0.role == .assistant }) {
                                 let serverContent = serverAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines)
                                 if !serverContent.isEmpty {
+                                    sawContent = true
                                     self.updateAssistantMessage(id: assistantMessageId, content: serverAssistant.content, isStreaming: true)
-                                    // Check if content is still growing
                                     if serverContent.count > lastContentLength {
                                         lastContentLength = serverContent.count
                                         staleCount = 0
                                     } else {
                                         staleCount += 1
                                     }
-                                    // If content hasn't changed for 3 consecutive polls (4.5s), it's done
-                                    if staleCount >= 3 {
-                                        self.logger.info("Polling: content stable at \(serverContent.count) chars — finalizing")
-                                        self.updateAssistantMessage(id: assistantMessageId, content: serverAssistant.content, isStreaming: false)
-                                        self.hasFinishedStreaming = true
-                                        self.isStreaming = false
-                                        // Post-completion
-                                        self.adoptServerMessages(serverConversation: refreshed)
-                                        await manager.sendChatCompleted(chatId: chatId, messageId: assistantMessageId, model: modelId, sessionId: socketSessionId, messages: self.buildSimpleAPIMessages())
-                                        try? await self.refreshConversationMetadata(chatId: chatId, assistantMessageId: assistantMessageId)
-                                        self.cleanupStreaming()
-                                        await self.sendCompletionNotificationIfNeeded(content: serverContent)
-                                        NotificationCenter.default.post(name: .conversationListNeedsRefresh, object: nil)
-                                        return
-                                    }
                                 }
+                                serverDone = !serverAssistant.isStreaming
                             }
                         } catch {
                             self.logger.warning("Polling failed: \(error.localizedDescription)")
                         }
+
+                        // ── Authoritative completion: server done flag ──
+                        if serverDone && sawContent {
+                            self.logger.info("Polling: server reports done — finalizing")
+                            await finalizePolling(latestConversation)
+                            return
+                        }
+                        if serverDone {
+                            // Done flag set but content not visible yet — give the
+                            // server a few extra polls to persist it before giving up.
+                            doneFlagPollCount += 1
+                            if doneFlagPollCount >= 3 {
+                                self.logger.info("Polling: server done with no content after \(doneFlagPollCount) polls — finalizing")
+                                await finalizePolling(latestConversation)
+                                return
+                            }
+                        }
+
+                        // ── Task-registry check when content isn't growing ──
+                        // While content grows the task is obviously alive; only
+                        // consult the registry once tokens stop arriving.
+                        guard staleCount > 0 || !sawContent else { continue }
+
+                        do {
+                            let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
+                            taskCheckFailures = 0
+                            if activeTaskIds.isEmpty {
+                                // Task finished — one final sync, then finalize.
+                                self.logger.info("Polling: server task finished (empty task list) — final sync")
+                                let final = (try? await manager.fetchConversation(id: chatId)) ?? latestConversation
+                                await finalizePolling(final)
+                                return
+                            }
+                            // Task still running (e.g. silent reasoning/web search)
+                            // — stay patient, never finalize on stale content.
+                            staleCount = 0
+                        } catch {
+                            taskCheckFailures += 1
+                            self.logger.warning("Polling: task-check failed (\(taskCheckFailures)): \(error.localizedDescription)")
+                            // Task API unreachable (e.g. older server) — fall back
+                            // to a conservative stability window: finalize only
+                            // after ~30s of static content (20 × 1.5s), not 4.5s.
+                            if taskCheckFailures >= 5 && staleCount >= 20 {
+                                self.logger.warning("Polling: task-check unreachable, content static for \(staleCount) polls — finalizing")
+                                await finalizePolling(latestConversation)
+                                return
+                            }
+                        }
                     }
-                    // Polling exhausted — finalize with whatever we have
+                    // Polling cancelled (stop button / navigation) — finalize with whatever we have
                     self.updateAssistantMessage(id: assistantMessageId,
                         content: self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? "",
                         isStreaming: false)
@@ -4476,6 +4566,7 @@ final class ChatViewModel {
             // ignore late-arriving accumulated content dispatches.
             guard let self, !self.hasFinishedStreaming else { return }
             self.socketHasReceivedContent = true
+            self.lastSocketContentAt = Date()
             self.updateAssistantMessage(id: msgId, content: content, isStreaming: true)
         }
 
@@ -4802,8 +4893,11 @@ final class ChatViewModel {
         effectiveChatId: String?,
         acc: ContentAccumulator
     ) {
-        // If content is empty, poll server for it
-        if acc.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        // If content is empty — or the recovery poll adopted newer server content
+        // the socket accumulator never saw (socket went silent mid-stream, issue
+        // #160) — poll the server for the authoritative full content instead of
+        // finalizing with a stale accumulator string.
+        if acc.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || recoveryAdoptedServerContent {
             Task {
                 await pollAndFinish(
                     assistantMessageId: assistantMessageId,
@@ -5103,11 +5197,20 @@ final class ChatViewModel {
                     polledContentLength = lastAssistant.content.count
 
                     // Server has more content than local — but ONLY update if the socket
-                    // has NOT been delivering tokens. If the socket is actively streaming,
-                    // let it continue token-by-token rather than dumping the entire server
-                    // content at once.
-                    if !serverContent.isEmpty && serverContent.count > localContent.count && !self.socketHasReceivedContent {
+                    // has NOT been delivering tokens, or has gone silent for >10s after
+                    // delivering earlier tokens (e.g. socket died mid-stream right after
+                    // a tool call — issue #160). If the socket is actively streaming,
+                    // let it continue token-by-token rather than dumping the entire
+                    // server content at once.
+                    let socketSilent = Date().timeIntervalSince(self.lastSocketContentAt) > 10
+                    if !serverContent.isEmpty && serverContent.count > localContent.count
+                        && (!self.socketHasReceivedContent || socketSilent) {
                         self.logger.info("Recovery: adopting server content (socket silent)")
+                        if self.socketHasReceivedContent {
+                            // The socket accumulator hasn't seen this newer content —
+                            // mark it so a late done:true can't finalize with stale acc content.
+                            self.recoveryAdoptedServerContent = true
+                        }
                         self.updateAssistantMessage(
                             id: assistantMessageId, content: lastAssistant.content, isStreaming: true)
                     }
@@ -5116,20 +5219,49 @@ final class ChatViewModel {
                     //
                     // Primary signal: server's done flag (set when chatCompleted is processed).
                     // Fallback signal: content-based detection — the response is structurally
-                    // complete when all tool-call blocks are closed, regardless of the done flag.
-                    // This catches the slow-connection case where the done:true socket event
-                    // was delayed or dropped and chatCompleted was never sent.
+                    // complete when all tool-call blocks are closed. BUT closed tool blocks
+                    // alone do NOT mean finished: a reasoning model routinely closes its
+                    // tool-call block (web search) and then thinks again — silently — before
+                    // writing the final answer (issue #160). So the structural signal is only
+                    // trusted after the server's task registry confirms no task is running,
+                    // or the task API is confirmed unreachable for older servers.
                     let serverDone = !lastAssistant.isStreaming
-                    let contentComplete = !serverContent.isEmpty && Self.toolCallResponseIsComplete(serverContent)
 
-                    if (serverDone || contentComplete) && !serverContent.isEmpty {
-                        self.logger.info("Recovery: finalizing — serverDone=\(serverDone) contentComplete=\(contentComplete) chars=\(serverContent.count)")
+                    func finalizeRecovery() {
+                        self.logger.info("Recovery: finalizing — serverDone=\(serverDone) chars=\(serverContent.count)")
                         self.updateAssistantMessage(
                             id: assistantMessageId, content: lastAssistant.content, isStreaming: false)
                         let doneContent = lastAssistant.content
                         Task { await self.sendCompletionNotificationIfNeeded(content: doneContent) }
                         self.cleanupStreaming()
+                    }
+
+                    if serverDone && !serverContent.isEmpty {
+                        finalizeRecovery()
                         return
+                    }
+
+                    if !serverContent.isEmpty && Self.toolCallResponseIsComplete(serverContent)
+                        && (!self.socketHasReceivedContent || socketSilent) {
+                        do {
+                            let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
+                            self.recoveryTaskCheckFailures = 0
+                            if activeTaskIds.isEmpty {
+                                finalizeRecovery()
+                                return
+                            }
+                            // Task still active — post-tool reasoning in progress; keep waiting.
+                            self.logger.debug("Recovery: tool blocks closed but task still active — waiting")
+                        } catch {
+                            self.recoveryTaskCheckFailures += 1
+                            // Only trust the structural signal once the task API is
+                            // confirmed unreachable (5 consecutive failures ≈ older server).
+                            if self.recoveryTaskCheckFailures >= 5 {
+                                self.logger.warning("Recovery: task-check unreachable, content structurally complete — finalizing")
+                                finalizeRecovery()
+                                return
+                            }
+                        }
                     }
                 }
             } catch {
@@ -5383,6 +5515,8 @@ final class ChatViewModel {
         lastRecoveryPollContentLength = 0
         recoveryTaskCheckFailures = 0
         recoveryTimerStartDate = .distantPast
+        lastSocketContentAt = .distantPast
+        recoveryAdoptedServerContent = false
         // or remove them if they never produced meaningful output
         if let lastIdx = conversation?.messages.lastIndex(where: { $0.role == .assistant }) {
             let statuses = conversation?.messages[lastIdx].statusHistory ?? []

--- a/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
@@ -3341,7 +3341,6 @@ final class ChatViewModel {
                     var lastContentLength = 0
                     var staleCount = 0
                     var taskCheckFailures = 0
-                    var doneFlagPollCount = 0
                     let pollingStartedAt = Date()
 
                     // Shared finalize path for every completion route below.
@@ -3378,8 +3377,6 @@ final class ChatViewModel {
                         }
 
                         var latestConversation: Conversation? = nil
-                        var serverDone = false
-                        var sawContent = false
 
                         do {
                             let refreshed = try await manager.fetchConversation(id: chatId)
@@ -3387,42 +3384,27 @@ final class ChatViewModel {
                             if let serverAssistant = refreshed.messages.last(where: { $0.role == .assistant }) {
                                 let serverContent = serverAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines)
                                 if !serverContent.isEmpty {
-                                    sawContent = true
                                     self.updateAssistantMessage(id: assistantMessageId, content: serverAssistant.content, isStreaming: true)
                                     if serverContent.count > lastContentLength {
+                                        // Content still growing — task obviously alive.
                                         lastContentLength = serverContent.count
                                         staleCount = 0
-                                    } else {
-                                        staleCount += 1
+                                        taskCheckFailures = 0
+                                        continue
                                     }
+                                    staleCount += 1
                                 }
-                                serverDone = !serverAssistant.isStreaming
                             }
                         } catch {
                             self.logger.warning("Polling failed: \(error.localizedDescription)")
                         }
 
-                        // ── Authoritative completion: server done flag ──
-                        if serverDone && sawContent {
-                            self.logger.info("Polling: server reports done — finalizing")
-                            await finalizePolling(latestConversation)
-                            return
-                        }
-                        if serverDone {
-                            // Done flag set but content not visible yet — give the
-                            // server a few extra polls to persist it before giving up.
-                            doneFlagPollCount += 1
-                            if doneFlagPollCount >= 3 {
-                                self.logger.info("Polling: server done with no content after \(doneFlagPollCount) polls — finalizing")
-                                await finalizePolling(latestConversation)
-                                return
-                            }
-                        }
-
                         // ── Task-registry check when content isn't growing ──
-                        // While content grows the task is obviously alive; only
-                        // consult the registry once tokens stop arriving.
-                        guard staleCount > 0 || !sawContent else { continue }
+                        // The server's done flag is NOT trusted here: it defaults
+                        // to true when omitted (MessageHistory parse) and can be
+                        // set before content is fully persisted. The registry is
+                        // authoritative — while it reports an active task the
+                        // model may be in a silent reasoning / tool phase (#157).
 
                         do {
                             let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
@@ -5217,18 +5199,25 @@ final class ChatViewModel {
 
                     // Determine if the response is complete.
                     //
-                    // Primary signal: server's done flag (set when chatCompleted is processed).
-                    // Fallback signal: content-based detection — the response is structurally
-                    // complete when all tool-call blocks are closed. BUT closed tool blocks
-                    // alone do NOT mean finished: a reasoning model routinely closes its
-                    // tool-call block (web search) and then thinks again — silently — before
-                    // writing the final answer (issue #160). So the structural signal is only
-                    // trusted after the server's task registry confirms no task is running,
-                    // or the task API is confirmed unreachable for older servers.
+                    // Two candidate signals: the server's done flag, and structural
+                    // completeness (all tool-call blocks closed). NEITHER is trusted
+                    // alone:
+                    //   • The done flag defaults to TRUE when the server omits it on
+                    //     in-progress messages (MessageHistory parse uses `?? true`),
+                    //     so it can read as "finished" mid-generation.
+                    //   • A reasoning model routinely closes its tool-call block (web
+                    //     search) and then thinks again — silently — before writing the
+                    //     final answer (issue #160).
+                    // The authoritative completion state is the server task registry:
+                    // finalize only when it reports no active tasks. The done/structural
+                    // signals remain as the fallback once the registry is CONFIRMED
+                    // unreachable (5 consecutive failures ≈ older server), preserving
+                    // the slow-connection rescue for a dropped done:true socket event.
                     let serverDone = !lastAssistant.isStreaming
+                    let contentComplete = !serverContent.isEmpty && Self.toolCallResponseIsComplete(serverContent)
 
                     func finalizeRecovery() {
-                        self.logger.info("Recovery: finalizing — serverDone=\(serverDone) chars=\(serverContent.count)")
+                        self.logger.info("Recovery: finalizing — serverDone=\(serverDone) contentComplete=\(contentComplete) chars=\(serverContent.count)")
                         self.updateAssistantMessage(
                             id: assistantMessageId, content: lastAssistant.content, isStreaming: false)
                         let doneContent = lastAssistant.content
@@ -5236,12 +5225,12 @@ final class ChatViewModel {
                         self.cleanupStreaming()
                     }
 
-                    if serverDone && !serverContent.isEmpty {
-                        finalizeRecovery()
-                        return
-                    }
-
-                    if !serverContent.isEmpty && Self.toolCallResponseIsComplete(serverContent)
+                    // Skip entirely while the socket is actively delivering tokens —
+                    // the done/structural signals are mid-stream heuristics and the
+                    // registry shouldn't be hammered on every 5s poll during healthy
+                    // streaming. Only consult them once the socket never delivered
+                    // anything or has gone silent.
+                    if (serverDone || contentComplete) && !serverContent.isEmpty
                         && (!self.socketHasReceivedContent || socketSilent) {
                         do {
                             let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
@@ -5251,13 +5240,13 @@ final class ChatViewModel {
                                 return
                             }
                             // Task still active — post-tool reasoning in progress; keep waiting.
-                            self.logger.debug("Recovery: tool blocks closed but task still active — waiting")
+                            self.logger.debug("Recovery: done/structural signal set but task still active — waiting")
                         } catch {
                             self.recoveryTaskCheckFailures += 1
-                            // Only trust the structural signal once the task API is
+                            // Only trust the done/structural signals once the task API is
                             // confirmed unreachable (5 consecutive failures ≈ older server).
                             if self.recoveryTaskCheckFailures >= 5 {
-                                self.logger.warning("Recovery: task-check unreachable, content structurally complete — finalizing")
+                                self.logger.warning("Recovery: task-check unreachable, done/structural signal set — finalizing")
                                 finalizeRecovery()
                                 return
                             }

--- a/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/Open UI/Features/Chat/ViewModels/ChatViewModel.swift
@@ -351,6 +351,12 @@ final class ChatViewModel {
     /// message back to the pre-silence prefix. finishStreamingSuccessfully()
     /// checks this flag and re-fetches the full content from the server instead.
     private var recoveryAdoptedServerContent = false
+    /// The content accumulator for the currently-active socket stream, if any.
+    /// When the recovery poll adopts newer server content during a socket-silence
+    /// window, it syncs this accumulator (replace) so a resuming socket continues
+    /// appending from the adopted content instead of replaying its stale shorter
+    /// prefix and visually shrinking the message.
+    private weak var activeAccumulator: ContentAccumulator?
     private(set) var serverBaseURL: String = ""
     @ObservationIgnored nonisolated(unsafe) private var foregroundObserver: NSObjectProtocol?
     @ObservationIgnored nonisolated(unsafe) private var backgroundObserver: NSObjectProtocol?
@@ -4527,6 +4533,7 @@ final class ChatViewModel {
         chatSubscription?.dispose()
         channelSubscription?.dispose()
         let acc = ContentAccumulator()
+        activeAccumulator = acc
 
         // For continue responses: pre-seed the accumulator with the existing message
         // content so that delta tokens are appended to the correct base.
@@ -5167,6 +5174,11 @@ final class ChatViewModel {
             // It is set inside the do-block and reused for the content-growth check after,
             // avoiding a second redundant fetchConversation call.
             var polledContentLength = self.lastRecoveryPollContentLength
+            // Set when the done/structural completion block below already queried the
+            // task registry this poll and found the task active — the static-content
+            // branch then skips its own registry query (dedupe; that combination is
+            // exactly the long silent post-tool-reasoning window of issue #160).
+            var registryConfirmedActiveThisPoll = false
 
             do {
                 let refreshed = try await manager.fetchConversation(id: chatId)
@@ -5193,6 +5205,9 @@ final class ChatViewModel {
                             // mark it so a late done:true can't finalize with stale acc content.
                             self.recoveryAdoptedServerContent = true
                         }
+                        // Sync the socket accumulator so a resuming socket appends from
+                        // the adopted content rather than replaying its stale prefix.
+                        self.activeAccumulator?.replace(lastAssistant.content)
                         self.updateAssistantMessage(
                             id: assistantMessageId, content: lastAssistant.content, isStreaming: true)
                     }
@@ -5241,6 +5256,7 @@ final class ChatViewModel {
                             }
                             // Task still active — post-tool reasoning in progress; keep waiting.
                             self.logger.debug("Recovery: done/structural signal set but task still active — waiting")
+                            registryConfirmedActiveThisPoll = true
                         } catch {
                             self.recoveryTaskCheckFailures += 1
                             // Only trust the done/structural signals once the task API is
@@ -5291,59 +5307,65 @@ final class ChatViewModel {
                     return
                 }
 
-                do {
-                    let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
-                    self.recoveryTaskCheckFailures = 0
+                if registryConfirmedActiveThisPoll {
+                    // Registry already queried above this poll and reported the task
+                    // active — just keep the give-up counters reset and wait.
+                    self.emptyPollCount = 0
+                } else {
+                    do {
+                        let activeTaskIds = try await manager.apiClient.getTasksForChat(chatId: chatId)
+                        self.recoveryTaskCheckFailures = 0
 
-                    if !activeTaskIds.isEmpty {
-                        // Server confirms the task is still running — stay patient and
-                        // reset emptyPollCount so the stale-content counter never fires
-                        // while the server is genuinely processing (e.g. long web search).
-                        self.logger.debug("Recovery: task still active (\(activeTaskIds.count) task(s)) — content=\(currentServerContentLength) chars, waiting")
-                        self.emptyPollCount = 0
-                    } else {
-                        // Server says the task is finished — do a final conversation fetch
-                        // and finalize so we display the complete response immediately.
-                        self.logger.info("Recovery: server task finished (empty task list) — performing final sync")
-                        if let refreshed = try? await manager.fetchConversation(id: chatId),
-                           let lastAssistant = refreshed.messages.last(where: { $0.role == .assistant }) {
-                            self.updateAssistantMessage(
-                                id: assistantMessageId,
-                                content: lastAssistant.content,
-                                isStreaming: false)
-                            let doneContent = lastAssistant.content
-                            Task { await self.sendCompletionNotificationIfNeeded(content: doneContent) }
+                        if !activeTaskIds.isEmpty {
+                            // Server confirms the task is still running — stay patient and
+                            // reset emptyPollCount so the stale-content counter never fires
+                            // while the server is genuinely processing (e.g. long web search).
+                            self.logger.debug("Recovery: task still active (\(activeTaskIds.count) task(s)) — content=\(currentServerContentLength) chars, waiting")
+                            self.emptyPollCount = 0
                         } else {
-                            let giveUpContent = self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? ""
-                            self.updateAssistantMessage(
-                                id: assistantMessageId,
-                                content: giveUpContent,
-                                isStreaming: false)
-                            Task { await self.sendCompletionNotificationIfNeeded(content: giveUpContent) }
-                        }
-                        self.cleanupStreaming()
-                    }
-                } catch {
-                    // Task-check network error — count consecutive failures
-                    self.recoveryTaskCheckFailures += 1
-                    self.logger.warning("Recovery: task-check failed (\(self.recoveryTaskCheckFailures)/5): \(error.localizedDescription)")
-                    if self.recoveryTaskCheckFailures >= 5 {
-                        // 5 consecutive failures means we can't reach the server reliably;
-                        // fall back to the old stale-content give-up threshold (12 polls).
-                        self.emptyPollCount += 1
-                        self.logger.debug("Recovery: falling back to stale-poll counter (\(self.emptyPollCount)/12) after task-check failures")
-                        if self.emptyPollCount >= 12 {
-                            self.logger.warning("Recovery: giving up after \(self.emptyPollCount) static polls (task-check unreachable)")
-                            let giveUpContent = self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? ""
-                            self.updateAssistantMessage(
-                                id: assistantMessageId,
-                                content: giveUpContent,
-                                isStreaming: false)
-                            Task { await self.sendCompletionNotificationIfNeeded(content: giveUpContent) }
+                            // Server says the task is finished — do a final conversation fetch
+                            // and finalize so we display the complete response immediately.
+                            self.logger.info("Recovery: server task finished (empty task list) — performing final sync")
+                            if let refreshed = try? await manager.fetchConversation(id: chatId),
+                               let lastAssistant = refreshed.messages.last(where: { $0.role == .assistant }) {
+                                self.updateAssistantMessage(
+                                    id: assistantMessageId,
+                                    content: lastAssistant.content,
+                                    isStreaming: false)
+                                let doneContent = lastAssistant.content
+                                Task { await self.sendCompletionNotificationIfNeeded(content: doneContent) }
+                            } else {
+                                let giveUpContent = self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? ""
+                                self.updateAssistantMessage(
+                                    id: assistantMessageId,
+                                    content: giveUpContent,
+                                    isStreaming: false)
+                                Task { await self.sendCompletionNotificationIfNeeded(content: giveUpContent) }
+                            }
                             self.cleanupStreaming()
                         }
+                    } catch {
+                        // Task-check network error — count consecutive failures
+                        self.recoveryTaskCheckFailures += 1
+                        self.logger.warning("Recovery: task-check failed (\(self.recoveryTaskCheckFailures)/5): \(error.localizedDescription)")
+                        if self.recoveryTaskCheckFailures >= 5 {
+                            // 5 consecutive failures means we can't reach the server reliably;
+                            // fall back to the old stale-content give-up threshold (12 polls).
+                            self.emptyPollCount += 1
+                            self.logger.debug("Recovery: falling back to stale-poll counter (\(self.emptyPollCount)/12) after task-check failures")
+                            if self.emptyPollCount >= 12 {
+                                self.logger.warning("Recovery: giving up after \(self.emptyPollCount) static polls (task-check unreachable)")
+                                let giveUpContent = self.conversation?.messages.last(where: { $0.role == .assistant })?.content ?? ""
+                                self.updateAssistantMessage(
+                                    id: assistantMessageId,
+                                    content: giveUpContent,
+                                    isStreaming: false)
+                                Task { await self.sendCompletionNotificationIfNeeded(content: giveUpContent) }
+                                self.cleanupStreaming()
+                            }
+                        }
+                        // If fewer than 5 failures, assume still running and keep waiting
                     }
-                    // If fewer than 5 failures, assume still running and keep waiting
                 }
             }
         }


### PR DESCRIPTION
Fixes #157
Fixes #160

## Root cause

Both issues are the same class of bug: the client **guessed** "generation finished" from visible content instead of asking the server.

- **#157** — the HTTP polling fallback (used when Socket.IO is unavailable) treated *4.5 seconds of unchanged content* as completion and hard-capped polling at ~60s. Long silent phases (local reasoning models, web-search ingestion, ~100s of prompt processing) make the persisted content static for far longer than that, so healthy generations looked like they randomly terminated.
- **#160** — the recovery poll treated *"all tool-call `<details>` blocks closed"* as completion. A reasoning model closes its web-search tool block and then **thinks again, silently**, before writing the final answer — so the stream was finalized exactly there, hiding the second thinking segment and the answer until the chat was reopened. The 5.3.5 fix only patched the static-content branch; this path was missed.

## What this changes

**Completion is now decided by the server's task registry** (`GET /api/tasks/chat/{chatId}`), as suggested in #157:

| Path | Before | After |
|---|---|---|
| Polling fallback | finalize after 4.5s stable content, 60s cap | poll while the task is registered; when it disappears, one final fetch → finalize; 10-min hard backstop |
| Recovery poll (done flag / closed tool blocks) | immediate finalize | finalize only when the registry confirms no active task |
| Registry unreachable (older servers) | n/a | conservative fallbacks: ~30s stability window (polling) / 5 consecutive failures before trusting done/structural signals (recovery) |

Additional fixes:

- **Server `done` flag no longer trusted for immediate finalize** — it parses as `true` when the server omits it on in-progress messages (`MessageHistory` uses `as? Bool ?? true`), which is itself a premature-finalize risk.
- **Live display restored for #160** — the recovery poll now tracks the last socket-delivered token time; when the socket has been silent >10s mid-stream it *adopts* the newer server content, so the second thinking segment and final answer stream in live instead of staying frozen until completion. The socket accumulator is synced on adoption so a resuming socket can't replay a stale prefix, and a late `done:true` re-fetches authoritative content instead of finalizing with the stale accumulator.
- **`MessageHistory.reconstructContentFromOutput` now entity-encodes tool-result and reasoning bodies** before embedding them in `<details>` blocks. Raw web-search HTML containing literal `<details>`/`</details>` corrupted the depth-aware block scanners in `ToolCallParser`/`StreamingPipeline` (mis-tracked boundaries leak or swallow content mid-render). The parse side already decodes entities on both the attribute and body-fallback paths, so rendering is unchanged.
- Registry check is skipped while the socket is actively delivering tokens, and deduped within a poll cycle, so healthy streams don't hammer the task API.

## ⚠️ Testing status — please read before merging

This patch was produced by two AI coding agents — **GLM 5.3** (via opencode) and **Qwen 3.8 Max** (via Claude Code) — working independently in separate worktrees, then cross-reviewing and merging the strongest version of each change.

**It has not been built in Xcode or run on a device/simulator.** Verification so far is source-level review against the OpenWebUI event/polling semantics plus `swiftc -parse` syntax checks only. Please build and test before merging — suggested repro for #160: ask a question that triggers thinking → web search → more thinking (e.g. *"what lounges are available at O'Hare Airport Terminal 5?"* with a reasoning model + web search enabled).
